### PR TITLE
fix fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Process all packages in the workspace
 * [accept-criteria-change](#cargo-vet-accept-criteria-change): Accept changes that a foreign audits.toml made to their criteria
 * [certify](#cargo-vet-certify): Mark `$package $version` as reviewed with `$message`
 * [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
-* [fetch](#cargo-vet-fetch): Fetch the source of `$package $version`
 * [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
 * [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 * [init](#cargo-vet-init): initialize cargo-vet for your project
+* [inspect](#cargo-vet-inspect): Fetch the source of `$package $version`
 * [suggest](#cargo-vet-suggest): Suggest some low-hanging fruit to review
 
 <br><br><br>
@@ -184,22 +184,22 @@ cargo vet diff <PACKAGE> <VERSION1> <VERSION2>
 Print help information
 
 <br><br><br>
-## cargo vet fetch 
+## cargo vet inspect 
 Fetch the source of `$package $version`
 
-### cargo vet fetch USAGE
+### cargo vet inspect USAGE
 ```
-cargo vet fetch <PACKAGE> <VERSION>
+cargo vet inspect <PACKAGE> <VERSION>
 ```
 
-### cargo vet fetch ARGS
+### cargo vet inspect ARGS
 #### `<PACKAGE>`
 
 
 #### `<VERSION>`
 
 
-### cargo vet fetch OPTIONS
+### cargo vet inspect OPTIONS
 #### `-h, --help`
 Print help information
 

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 65
+assertion_line: 68
 expression: stdout
 ---
 cargo-vet 0.1.0
@@ -59,14 +59,14 @@ SUBCOMMANDS:
             Mark `$package $version` as reviewed with `$message`
     diff
             Yield a diff against the last reviewed version
-    fetch
-            Fetch the source of `$package $version`
     fmt
             Reformat all of vet's files (in case you hand-edited them)
     help
             Print this message or the help of the given subcommand(s)
     init
             initialize cargo-vet for your project
+    inspect
+            Fetch the source of `$package $version`
     suggest
             Suggest some low-hanging fruit to review
 

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 103
+assertion_line: 106
 expression: stdout
 ---
 # cargo vet CLI manual
@@ -61,10 +61,10 @@ Process all packages in the workspace
 * [accept-criteria-change](#cargo-vet-accept-criteria-change): Accept changes that a foreign audits.toml made to their criteria
 * [certify](#cargo-vet-certify): Mark `$package $version` as reviewed with `$message`
 * [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
-* [fetch](#cargo-vet-fetch): Fetch the source of `$package $version`
 * [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
 * [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 * [init](#cargo-vet-init): initialize cargo-vet for your project
+* [inspect](#cargo-vet-inspect): Fetch the source of `$package $version`
 * [suggest](#cargo-vet-suggest): Suggest some low-hanging fruit to review
 
 <br><br><br>
@@ -166,22 +166,22 @@ cargo vet diff <PACKAGE> <VERSION1> <VERSION2>
 Print help information
 
 <br><br><br>
-## cargo vet fetch 
+## cargo vet inspect 
 Fetch the source of `$package $version`
 
-### cargo vet fetch USAGE
+### cargo vet inspect USAGE
 ```
-cargo vet fetch <PACKAGE> <VERSION>
+cargo vet inspect <PACKAGE> <VERSION>
 ```
 
-### cargo vet fetch ARGS
+### cargo vet inspect ARGS
 #### `<PACKAGE>`
 
 
 #### `<VERSION>`
 
 
-### cargo vet fetch OPTIONS
+### cargo vet inspect OPTIONS
 #### `-h, --help`
 Print help information
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 84
+assertion_line: 87
 expression: stdout
 ---
 cargo-vet 0.1.0
@@ -30,9 +30,9 @@ SUBCOMMANDS:
     accept-criteria-change    Accept changes that a foreign audits.toml made to their criteria
     certify                   Mark `$package $version` as reviewed with `$message`
     diff                      Yield a diff against the last reviewed version
-    fetch                     Fetch the source of `$package $version`
     fmt                       Reformat all of vet's files (in case you hand-edited them)
     help                      Print this message or the help of the given subcommand(s)
     init                      initialize cargo-vet for your project
+    inspect                   Fetch the source of `$package $version`
     suggest                   Suggest some low-hanging fruit to review
 


### PR DESCRIPTION
This partially resurrects the janky vendor hack, but instead of actually vendoring, we just `cargo fetch` to ensure the cache is populated. Name conflicts have been fixed by abusing the rename mechanism to essentially mangle package names.

This seems to now work reliably, but I wouldn't be surprised if Interesting inputs still pushed it over.

pushd functionality not implemented because... I actually don't know how to have a program tell the shell to do that? Like it's not a real program, but a shell primitive, right? (Interestingly powershell also supports this primitive, so it might be portable still...)