### PR TITLE
Catchup On The Book

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -311,12 +311,14 @@ static DEFAULT_POLICY_BUILD_AND_DEV_CRITERIA: &str = SAFE_TO_RUN;
 pub fn get_default_policy_criteria() -> Vec<String> {
     vec![DEFAULT_POLICY_CRITERIA.to_string()]
 }
+#[allow(clippy::ptr_arg)]
 fn is_default_policy_criteria(val: &Vec<String>) -> bool {
     val.len() == 1 && val[0] == DEFAULT_POLICY_CRITERIA
 }
 pub fn get_default_policy_build_and_dev_criteria() -> Vec<String> {
     vec![DEFAULT_POLICY_BUILD_AND_DEV_CRITERIA.to_string()]
 }
+#[allow(clippy::ptr_arg)]
 fn is_default_policy_build_and_dev_criteria(val: &Vec<String>) -> bool {
     val.len() == 1 && val[0] == DEFAULT_POLICY_BUILD_AND_DEV_CRITERIA
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,348 @@
+//! Details of the file formats used by cargo vet
+
+use core::fmt;
+use std::path::{Path, PathBuf};
+
+use cargo_metadata::{Version, VersionReq};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::VetError;
+
+pub type StableMap<K, V> = linked_hash_map::LinkedHashMap<K, V>;
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+//                                                                                //
+//                 Metaconfigs (found in Cargo.tomls)                             //
+//                                                                                //
+//                                                                                //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+/// A `[*.metadata.vet]` table in a Cargo.toml, configuring our behaviour
+#[derive(serde::Deserialize)]
+pub struct MetaConfigInstance {
+    // Reserved for future use, if not present version=1 assumed.
+    // (not sure whether this versions the format, or semantics, or...
+    // for now assuming this species global semantics of some kind.
+    pub version: Option<u64>,
+    pub store: Option<Store>,
+}
+#[derive(serde::Deserialize)]
+pub struct Store {
+    pub path: Option<PathBuf>,
+}
+
+// FIXME: It's *possible* for someone to have a workspace but not have a
+// global `vet` instance for the whole workspace. In this case they *could*
+// have individual `vet` instances for each subcrate they care about.
+// This is... Weird, and it's unclear what that *means*... but maybe it's valid?
+// Either way, we definitely don't support it right now!
+
+/// All available configuration files, overlaying eachother.
+/// Generally contains: `[Default, Workspace, Package]`
+pub struct MetaConfig(pub Vec<MetaConfigInstance>);
+
+impl MetaConfig {
+    pub fn store_path(&self) -> &Path {
+        // Last config gets priority to set this
+        for config in self.0.iter().rev() {
+            if let Some(store) = &config.store {
+                if let Some(path) = &store.path {
+                    return path;
+                }
+            }
+        }
+        unreachable!("Default config didn't define store.path???");
+    }
+    pub fn version(&self) -> u64 {
+        // Last config gets priority to set this
+        for config in self.0.iter().rev() {
+            if let Some(ver) = config.version {
+                return ver;
+            }
+        }
+        unreachable!("Default config didn't define version???");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+//                                                                                //
+//                                audits.toml                                     //
+//                                                                                //
+//                                                                                //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+pub type AuditedDependencies = StableMap<String, Vec<AuditEntry>>;
+
+/// audits.toml
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct AuditsFile {
+    /// A map of criteria_name to details on that criteria.
+    pub criteria: StableMap<String, CriteriaEntry>,
+    /// Actual audits.
+    pub audits: AuditedDependencies,
+}
+
+impl AuditsFile {
+    pub fn validate(&self) -> Result<(), VetError> {
+        // TODO
+        Ok(())
+    }
+}
+
+/// Information on a Criteria
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct CriteriaEntry {
+    /// Summary of how you evaluate something by this criteria.
+    pub description: String,
+    /// Whether this criteria is part of the "defaults"
+    pub default: bool,
+    /// Criteria that this one implies
+    pub implies: Vec<String>,
+}
+
+/// This is just a big vague ball initially. It's up to the Audits/Unuadited/Trusted wrappers
+/// to validate if it "makes sense" for their particular function.
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct AuditEntry {
+    pub version: Option<Version>,
+    pub delta: Option<Delta>,
+    pub violation: Option<VersionReq>,
+    pub who: Option<String>,
+    pub notes: Option<String>,
+    pub criteria: Option<Vec<String>>,
+    #[serde(rename = "dependency-criteria")]
+    pub dependency_criteria: Option<DependencyCriteria>,
+}
+
+impl AuditEntry {
+    /// Not actually valid, but a starting point for other things
+    pub fn null() -> Self {
+        Self {
+            version: None,
+            delta: None,
+            violation: None,
+            who: None,
+            notes: None,
+            criteria: None,
+            dependency_criteria: None,
+        }
+    }
+    pub fn violation(req: VersionReq) -> Self {
+        Self {
+            violation: Some(req),
+            ..Self::null()
+        }
+    }
+    pub fn full_audit(version: Version) -> Self {
+        Self {
+            version: Some(version),
+            ..Self::null()
+        }
+    }
+    pub fn delta_audit(from: Version, to: Version) -> Self {
+        Self {
+            delta: Some(Delta { from, to }),
+            ..Self::null()
+        }
+    }
+}
+
+/// A list of criteria that transitive dependencies must satisfy for this
+/// audit to continue to be considered valid.
+///
+/// Example:
+///
+/// ```toml
+/// dependency_criteria = { hmac: ['secure', 'crypto_reviewed'] }
+/// ```
+pub type DependencyCriteria = StableMap<String, Vec<String>>;
+
+/// A "VERSION -> VERSION"
+#[derive(Debug)]
+pub struct Delta {
+    pub from: Version,
+    pub to: Version,
+}
+
+impl<'de> Deserialize<'de> for Delta {
+    fn deserialize<D>(deserializer: D) -> Result<Delta, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DeltaVisitor;
+        impl<'de> Visitor<'de> for DeltaVisitor {
+            type Value = Delta;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a delta of the form 'VERSION -> VERSION'")
+            }
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if let Some((from, to)) = s.split_once("->") {
+                    Ok(Delta {
+                        from: Version::parse(from.trim()).map_err(de::Error::custom)?,
+                        to: Version::parse(to.trim()).map_err(de::Error::custom)?,
+                    })
+                } else {
+                    Err(de::Error::invalid_value(de::Unexpected::Str(s), &self))
+                }
+            }
+        }
+
+        deserializer.deserialize_str(DeltaVisitor)
+    }
+}
+
+impl Serialize for Delta {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let output = format!("{} -> {}", self.from, self.to);
+        serializer.serialize_str(&output)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+//                                                                                //
+//                                config.toml                                     //
+//                                                                                //
+//                                                                                //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+/// config.toml
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ConfigFile {
+    /// Remote audits.toml's that we trust and want to import.
+    pub imports: StableMap<String, RemoteImport>,
+    /// All of the "foreign" dependencies that we rely on but haven't audited yet.
+    /// Foreign dependencies are just "things on crates.io", everything else
+    /// (paths, git, etc) is assumed to be "under your control" and therefore implicitly trusted.
+    pub unaudited: StableMap<String, Vec<UnauditedDependency>>,
+    pub policy: PolicyTable,
+}
+
+impl ConfigFile {
+    pub fn validate(&self) -> Result<(), VetError> {
+        // TODO
+        Ok(())
+    }
+}
+
+/// Policies that first-party (non-foreign) crates must pass.
+///
+/// This is basically the first-party equivalent of audits.toml, which is separated out
+/// because it's not supposed to be shared (or, doesn't really make sense to share,
+/// since first-party crates are defined by "not on crates.io").
+///
+/// Because first-party crates are implicitly trusted, really the only purpose of this
+/// table is to define the boundary between a first-party crates and third-party ones.
+/// More specifically, the criteria of the dependency edges between a first-party crate
+/// and its direct third-party dependencies.
+///
+/// If this sounds overwhelming, don't worry, everything defaults to "nothing special"
+/// and an empty PolicyTable basically just means "everything should satisfy the
+/// default criteria in audits.toml".
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct PolicyTable {
+    /// Default criteria that must be satisfied by all *direct* third-party (foreign)
+    /// dependencies of first-party crates. If satisfied, the first-party crate is
+    /// set to satisfying all criteria.
+    ///
+    /// If not present, this defaults to the default criteria in the audits table.
+    pub criteria: Option<Vec<String>>,
+
+    /// Custom criteria for a specific first-party crate's dependencies. It's nonsensical
+    /// to define criteria between two first-party crates, so you can only name third-party
+    /// dependencies here.
+    ///
+    /// Any dependency edge that isn't explicitly specified defaults to `criteria`.
+    #[serde(rename = "dependency-criteria")]
+    pub dependency_criteria: Option<DependencyCriteria>,
+
+    /// Same as `criteria`, but for first-party(?) crates/dependencies that are only
+    /// used as build-dependencies or dev-dependencies.
+    #[serde(rename = "build-and-dev-criteria")]
+    pub build_and_dev_criteria: Option<Vec<String>>,
+
+    /// TODO: figure this out
+    pub targets: Option<Vec<String>>,
+
+    /// `targets` but build/dev
+    #[serde(rename = "build-and-dev-targets")]
+    pub build_and_dev_targets: Option<Vec<String>>,
+}
+
+/// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct RemoteImport {
+    /// URL of the foreign audits.toml
+    pub url: String,
+    /// A list of criteria that are implied by foreign criteria
+    #[serde(rename = "criteria-map")]
+    pub criteria_map: Vec<CriteriaMapping>,
+}
+
+/// Translations of foreign criteria to local criteria.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CriteriaMapping {
+    /// This local criteria is implied...
+    pub ours: String,
+    /// If all of these foreign criteria apply
+    pub theirs: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct UnauditedDependency {
+    /// The version(s) of the crate that we are currently "fine" with leaving unaudited.
+    /// For the sake of consistency, I'm making this a proper Cargo VersionReq:
+    /// <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html>
+    ///
+    /// One significant implication of this is that x.y.z is *not* one version. It is
+    /// ^x.y.z, per Cargo convention. You must use =x.y.z to be that specific. We will
+    /// do this for you when we do `cargo vet init`, so this shouldn't be a big deal?
+    pub version: Version,
+    /// Criteria that we're willing to handwave for this version. If nothing specified,
+    /// this is all_criteria (TODO: rejig init so that this is very an Option!).
+    pub criteria: Option<Vec<String>>,
+    /// Freeform notes, put whatever you want here. Just more stable/reliable than comments.
+    pub notes: Option<String>,
+    /// Whether suggest should bother mentioning this (defaults true)
+    pub suggest: bool,
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+//                                                                                //
+//                                imports.lock                                    //
+//                                                                                //
+//                                                                                //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+/// imports.lock, not sure what I want to put in here yet.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ImportsFile {
+    pub audits: StableMap<String, AuditsFile>,
+}
+
+impl ImportsFile {
+    pub fn validate(&self) -> Result<(), VetError> {
+        // TODO
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,32 @@
 use std::ffi::OsString;
+use std::fs;
 use std::fs::OpenOptions;
 use std::io::{BufReader, Read};
 use std::ops::Deref;
 use std::path::Path;
 use std::process::Command;
-use std::{fmt, fs};
 use std::{fs::File, io::Write, panic, path::PathBuf};
 
-use cargo_metadata::{Metadata, Package, Version, VersionReq};
+use cargo_metadata::{Metadata, Package, Version};
 use clap::{ArgEnum, CommandFactory, Parser, Subcommand};
+use format::{AuditEntry, Delta, MetaConfig};
 use log::{error, info, trace, warn};
 use reqwest::blocking as req;
-use serde::de::Visitor;
-use serde::{de, de::Deserialize, ser::Serialize};
-use serde::{Deserializer, Serializer};
+use serde::{de::Deserialize, ser::Serialize};
 use simplelog::{
     ColorChoice, ConfigBuilder, Level, LevelFilter, TermLogger, TerminalMode, WriteLogger,
 };
 
+use crate::format::{
+    AuditsFile, ConfigFile, CriteriaEntry, ImportsFile, MetaConfigInstance, PolicyTable, StableMap,
+    Store, UnauditedDependency,
+};
+
+pub mod format;
 mod resolver;
 #[cfg(test)]
 mod tests;
 
-type StableMap<K, V> = linked_hash_map::LinkedHashMap<K, V>;
 type VetError = eyre::Report;
 
 #[derive(Parser)]
@@ -163,298 +167,6 @@ pub struct Config {
     cargo: OsString,
     tmp: PathBuf,
     registry_src: Option<PathBuf>,
-}
-
-/// A `[*.metadata.vet]` table in a Cargo.toml, configuring our behaviour
-#[derive(serde::Deserialize)]
-pub struct MetaConfigInstance {
-    // Reserved for future use, if not present version=1 assumed.
-    // (not sure whether this versions the format, or semantics, or...
-    // for now assuming this species global semantics of some kind.
-    version: Option<u64>,
-    store: Option<Store>,
-}
-#[derive(serde::Deserialize)]
-pub struct Store {
-    path: Option<PathBuf>,
-}
-
-// FIXME: It's *possible* for someone to have a workspace but not have a
-// global `vet` instance for the whole workspace. In this case they *could*
-// have individual `vet` instances for each subcrate they care about.
-// This is... Weird, and it's unclear what that *means*... but maybe it's valid?
-// Either way, we definitely don't support it right now!
-
-/// All available configuration files, overlaying eachother.
-/// Generally contains: `[Default, Workspace, Package]`
-pub struct MetaConfig(Vec<MetaConfigInstance>);
-
-impl MetaConfig {
-    fn store_path(&self) -> &Path {
-        // Last config gets priority to set this
-        for config in self.0.iter().rev() {
-            if let Some(store) = &config.store {
-                if let Some(path) = &store.path {
-                    return path;
-                }
-            }
-        }
-        unreachable!("Default config didn't define store.path???");
-    }
-    fn version(&self) -> u64 {
-        // Last config gets priority to set this
-        for config in self.0.iter().rev() {
-            if let Some(ver) = config.version {
-                return ver;
-            }
-        }
-        unreachable!("Default config didn't define version???");
-    }
-}
-
-pub type AuditedDependencies = StableMap<String, Vec<AuditEntry>>;
-
-/// audits.toml
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct AuditsFile {
-    /// A map of criteria_name to details on that criteria.
-    criteria: StableMap<String, CriteriaEntry>,
-    /// Actual audits.
-    audits: AuditedDependencies,
-}
-
-/// imports.lock, not sure what I want to put in here yet.
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct ImportsFile {
-    audits: StableMap<String, AuditsFile>,
-}
-
-/// config.toml
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct ConfigFile {
-    /// Remote audits.toml's that we trust and want to import.
-    imports: StableMap<String, RemoteImport>,
-    /// All of the "foreign" dependencies that we rely on but haven't audited yet.
-    /// Foreign dependencies are just "things on crates.io", everything else
-    /// (paths, git, etc) is assumed to be "under your control" and therefore implicitly trusted.
-    unaudited: StableMap<String, Vec<UnauditedDependency>>,
-    policy: PolicyTable,
-}
-
-/// Information on a Criteria
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-pub struct CriteriaEntry {
-    /// Summary of how you evaluate something by this criteria.
-    description: String,
-    /// Whether this criteria is part of the "defaults"
-    default: bool,
-    /// Criteria that this one implies
-    implies: Vec<String>,
-}
-
-/// Policies that first-party (non-foreign) crates must pass.
-///
-/// This is basically the first-party equivalent of audits.toml, which is separated out
-/// because it's not supposed to be shared (or, doesn't really make sense to share,
-/// since first-party crates are defined by "not on crates.io").
-///
-/// Because first-party crates are implicitly trusted, really the only purpose of this
-/// table is to define the boundary between a first-party crates and third-party ones.
-/// More specifically, the criteria of the dependency edges between a first-party crate
-/// and its direct third-party dependencies.
-///
-/// If this sounds overwhelming, don't worry, everything defaults to "nothing special"
-/// and an empty PolicyTable basically just means "everything should satisfy the
-/// default criteria in audits.toml".
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct PolicyTable {
-    /// Default criteria that must be satisfied by all *direct* third-party (foreign)
-    /// dependencies of first-party crates. If satisfied, the first-party crate is
-    /// set to satisfying all criteria.
-    ///
-    /// If not present, this defaults to the default criteria in the audits table.
-    criteria: Option<Vec<String>>,
-
-    /// Custom criteria for a specific first-party crate's dependencies. It's nonsensical
-    /// to define criteria between two first-party crates, so you can only name third-party
-    /// dependencies here.
-    ///
-    /// Any dependency edge that isn't explicitly specified defaults to `criteria`.
-    #[serde(rename = "dependency-criteria")]
-    dependency_criteria: Option<DependencyCriteria>,
-
-    /// Same as `criteria`, but for first-party(?) crates/dependencies that are only
-    /// used as build-dependencies or dev-dependencies.
-    #[serde(rename = "build-and-dev-criteria")]
-    build_and_dev_criteria: Option<Vec<String>>,
-
-    /// TODO: figure this out
-    targets: Option<Vec<String>>,
-
-    /// `targets` but build/dev
-    #[serde(rename = "build-and-dev-targets")]
-    build_and_dev_targets: Option<Vec<String>>,
-}
-
-/// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct RemoteImport {
-    /// URL of the foreign audits.toml
-    url: String,
-    /// A list of criteria that are implied by foreign criteria
-    #[serde(rename = "criteria-map")]
-    criteria_map: Vec<CriteriaMapping>,
-}
-
-/// Translations of foreign criteria to local criteria.
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct CriteriaMapping {
-    /// This local criteria is implied...
-    ours: String,
-    /// If all of these foreign criteria apply
-    theirs: Vec<String>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct UnauditedDependency {
-    /// The version(s) of the crate that we are currently "fine" with leaving unaudited.
-    /// For the sake of consistency, I'm making this a proper Cargo VersionReq:
-    /// <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html>
-    ///
-    /// One significant implication of this is that x.y.z is *not* one version. It is
-    /// ^x.y.z, per Cargo convention. You must use =x.y.z to be that specific. We will
-    /// do this for you when we do `cargo vet init`, so this shouldn't be a big deal?
-    version: Version,
-    /// Criteria that we're willing to handwave for this version. If nothing specified,
-    /// this is all_criteria (TODO: rejig init so that this is very an Option!).
-    criteria: Option<Vec<String>>,
-    /// Freeform notes, put whatever you want here. Just more stable/reliable than comments.
-    notes: Option<String>,
-    /// Whether suggest should bother mentioning this (defaults true)
-    suggest: bool,
-}
-
-/// This is just a big vague ball initially. It's up to the Audits/Unuadited/Trusted wrappers
-/// to validate if it "makes sense" for their particular function.
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub struct AuditEntry {
-    version: Option<Version>,
-    delta: Option<Delta>,
-    violation: Option<VersionReq>,
-    who: Option<String>,
-    notes: Option<String>,
-    criteria: Option<Vec<String>>,
-    #[serde(rename = "dependency-criteria")]
-    dependency_criteria: Option<DependencyCriteria>,
-}
-
-impl AuditEntry {
-    /// Not actually valid, but a starting point for other things
-    pub fn null() -> Self {
-        Self {
-            version: None,
-            delta: None,
-            violation: None,
-            who: None,
-            notes: None,
-            criteria: None,
-            dependency_criteria: None,
-        }
-    }
-    pub fn violation(req: VersionReq) -> Self {
-        Self {
-            violation: Some(req),
-            ..Self::null()
-        }
-    }
-    pub fn full_audit(version: Version) -> Self {
-        Self {
-            version: Some(version),
-            ..Self::null()
-        }
-    }
-    pub fn delta_audit(from: Version, to: Version) -> Self {
-        Self {
-            delta: Some(Delta { from, to }),
-            ..Self::null()
-        }
-    }
-}
-
-/// A list of criteria that transitive dependencies must satisfy for this
-/// audit to continue to be considered valid.
-///
-/// Example:
-///
-/// ```toml
-/// dependency_criteria = { hmac: ['secure', 'crypto_reviewed'] }
-/// ```
-pub type DependencyCriteria = StableMap<String, Vec<String>>;
-
-/// A "VERSION -> VERSION"
-#[derive(Debug)]
-pub struct Delta {
-    from: Version,
-    to: Version,
-}
-
-impl<'de> Deserialize<'de> for Delta {
-    fn deserialize<D>(deserializer: D) -> Result<Delta, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct DeltaVisitor;
-        impl<'de> Visitor<'de> for DeltaVisitor {
-            type Value = Delta;
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a delta of the form 'VERSION -> VERSION'")
-            }
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                if let Some((from, to)) = s.split_once("->") {
-                    Ok(Delta {
-                        from: Version::parse(from.trim()).map_err(de::Error::custom)?,
-                        to: Version::parse(to.trim()).map_err(de::Error::custom)?,
-                    })
-                } else {
-                    Err(de::Error::invalid_value(de::Unexpected::Str(s), &self))
-                }
-            }
-        }
-
-        deserializer.deserialize_str(DeltaVisitor)
-    }
-}
-
-impl Serialize for Delta {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let output = format!("{} -> {}", self.from, self.to);
-        serializer.serialize_str(&output)
-    }
-}
-
-impl ConfigFile {
-    fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        Ok(())
-    }
-}
-impl ImportsFile {
-    fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        Ok(())
-    }
-}
-impl AuditsFile {
-    fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        Ok(())
-    }
 }
 
 static EMPTY_PACKAGE: &str = "empty";

--- a/tests/test-project/supply-chain/audits.toml
+++ b/tests/test-project/supply-chain/audits.toml
@@ -1,91 +1,83 @@
-
 # cargo-vet audits file
 
-[criteria.skimmed]
-description = "you skimmed it and it seems fine"
-default = true
-implies = []
-
-[criteria.reviewed]
-description = "you reviewed it properly"
-default = true
-implies = ["skimmed"]
-
 [criteria.audited]
-description = "you fully audited it"
-default = false
-implies = ["reviewed"]
+implies = ["safe-to-deploy"]
+description = "super audited"
 
 [criteria.fuzzed]
-description = "you fuzzed it"
-default = false
-implies = []
-
+description = "fuzzed"
 
 
 
 [[audits.base64]]
 version = "0.1.0"
+criteria = "safe-to-deploy"
 message = "test for basic resolution"
 
 [[audits.base64]]
 delta = "0.2.0 -> 0.14.0"
+criteria = "safe-to-deploy"
 
 [[audits.base64]]
 delta = "0.1.0 -> 0.4.0"
+criteria = "safe-to-deploy"
 
 [[audits.base64]]
 version = "0.5.0"
+criteria = "safe-to-deploy"
 message = "basic resolution"
 
 [[audits.base64]]
 delta = "0.9.0 -> 0.13.0"
+criteria = "safe-to-deploy"
 
 [[audits.base64]]
 delta = "0.8.1 -> 0.9.0"
+criteria = "safe-to-deploy"
 
 [[audits.base64]]
 delta = "0.4.0 -> 0.8.1"
-
+criteria = "safe-to-deploy"
 
 
 
 [[audits.autocfg]]
 version = "1.1.0"
-criteria = ["audited", "fuzzed"]
+criteria = "safe-to-deploy"
 message = "test for simple absolute version with non-defaults"
 
 [[audits.clap]]
 version = "3.1.8"
 message = "test for custom criteria (low-grade and high-grade)"
-dependency-criteria = { "atty" = ["skimmed"], "bitflags" = ["audited", "fuzzed"] }
+criteria = "safe-to-deploy"
+dependency-criteria = { "atty" = ["safe-to-run"], "bitflags" = ["audited", "fuzzed"] }
 
 [[audits.atty]]
 version = "0.2.14"
-criteria = ["skimmed"]
+criteria = "safe-to-run"
 
 
 
 [[audits.bitflags]]
 version = "0.1.0"
 message = "test for unioning criteria from two chains"
-criteria = ["audited"]
+criteria = "audited"
 
 [[audits.bitflags]]
 delta = "0.1.0 -> 1.3.2"
-criteria = ["audited"]
+criteria = "audited"
 
 [[audits.bitflags]]
 version = "0.2.0"
-criteria = ["fuzzed"]
+criteria = "fuzzed"
 
 [[audits.bitflags]]
 delta = "0.2.0 -> 1.3.2"
-criteria = ["fuzzed"]
+criteria = "fuzzed"
 
 
 
 [[audits.unicode-bidi]]
 delta = "0.2.0 -> 0.3.7"
 message = "test for delta to unaudited"
-
+criteria = "safe-to-deploy"

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -2,505 +2,500 @@
 # cargo-vet config file
 
 [imports]
-
-
-
-
 [[unaudited.bumpalo]]
 version = "3.9.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.bytes]]
 version = "1.1.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.cc]]
 version = "1.0.73"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.cfg-if]]
 version = "1.0.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
-
 
 [[unaudited.core-foundation]]
 version = "0.9.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.core-foundation-sys]]
 version = "0.8.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.encoding_rs]]
 version = "0.8.31"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.fastrand]]
 version = "1.7.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.fnv]]
 version = "1.0.7"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.foreign-types]]
 version = "0.3.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.foreign-types-shared]]
 version = "0.1.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.form_urlencoded]]
 version = "1.0.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.futures-channel]]
 version = "0.3.21"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.futures-core]]
 version = "0.3.21"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.futures-sink]]
 version = "0.3.21"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.futures-task]]
 version = "0.3.21"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.futures-util]]
 version = "0.3.21"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.h2]]
 version = "0.3.13"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.hashbrown]]
 version = "0.11.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.hermit-abi]]
 version = "0.1.19"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.http]]
 version = "0.2.6"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.http-body]]
 version = "0.4.4"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.httparse]]
 version = "1.7.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.httpdate]]
 version = "1.0.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.hyper]]
 version = "0.14.18"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.hyper-tls]]
 version = "0.5.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.idna]]
 version = "0.2.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.indexmap]]
 version = "1.8.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.instant]]
 version = "0.1.12"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.ipnet]]
 version = "2.4.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.itoa]]
 version = "1.0.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.js-sys]]
 version = "0.3.57"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.lazy_static]]
 version = "1.4.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.libc]]
 version = "0.2.123"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.log]]
 version = "0.4.16"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.matches]]
 version = "0.1.9"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.memchr]]
 version = "2.4.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.mime]]
 version = "0.3.16"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.mio]]
 version = "0.8.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.miow]]
 version = "0.3.7"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.native-tls]]
 version = "0.2.10"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.ntapi]]
 version = "0.3.7"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.once_cell]]
 version = "1.10.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.openssl]]
 version = "0.10.38"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.openssl-probe]]
 version = "0.1.5"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.openssl-sys]]
 version = "0.9.72"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.os_str_bytes]]
 version = "6.0.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.percent-encoding]]
 version = "2.1.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.pin-project-lite]]
 version = "0.2.8"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.pin-utils]]
 version = "0.1.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.pkg-config]]
 version = "0.3.25"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.proc-macro2]]
 version = "1.0.37"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.quote]]
 version = "1.0.18"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.redox_syscall]]
 version = "0.2.13"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.remove_dir_all]]
 version = "0.5.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.reqwest]]
 version = "0.11.10"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.ryu]]
 version = "1.0.9"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.schannel]]
 version = "0.1.19"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.security-framework]]
 version = "2.6.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.security-framework-sys]]
 version = "2.6.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.serde]]
 version = "1.0.136"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.serde_json]]
 version = "1.0.79"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.serde_urlencoded]]
 version = "0.7.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.slab]]
 version = "0.4.6"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.socket2]]
 version = "0.4.4"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.strsim]]
 version = "0.10.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.syn]]
 version = "1.0.91"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tempfile]]
 version = "3.3.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.termcolor]]
 version = "1.1.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.textwrap]]
 version = "0.15.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tinyvec]]
 version = "1.5.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tinyvec_macros]]
 version = "0.1.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tokio]]
 version = "1.17.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tokio-native-tls]]
 version = "0.3.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tokio-util]]
 version = "0.7.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tower-service]]
 version = "0.3.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tracing]]
 version = "0.1.33"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tracing-attributes]]
 version = "0.1.20"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.tracing-core]]
 version = "0.1.25"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.try-lock]]
 version = "0.2.3"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.unicode-bidi]]
 version = "0.2.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.unicode-normalization]]
 version = "0.1.19"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.unicode-xid]]
 version = "0.2.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.url]]
 version = "2.2.2"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.vcpkg]]
 version = "0.2.15"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.want]]
 version = "0.3.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasi]]
 version = "0.11.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen-backend]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen-futures]]
 version = "0.4.30"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen-macro]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen-macro-support]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.wasm-bindgen-shared]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.web-sys]]
 version = "0.3.57"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.winapi]]
 version = "0.3.9"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.winapi-util]]
 version = "0.1.5"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [[unaudited.winreg]]
 version = "0.10.1"
+criteria = "safe-to-deploy"
 notes = "automatically imported by 'cargo vet init'"
-suggest = true
 
 [policy]
 


### PR DESCRIPTION
This factors out the file format to its own module, and then pulls a lot more stuff in line with what the book says. Also introduces a ton more serde magic for defaults.

A lot of testing stuff had to be rejigged because the book has kind of changed a lot of defaults from "super late bound" to "super early bound", and the test harness was abusing the late-boundness to elide things that were the default.

Also now the test suite is a little weird in that it's kinda explicitly blanketing over the existence of the builtins. However the "test project" has been updated to use the builtins where it makes sense, so that's good.

Any kind of build_and_dev distinction is still largely ignored and stubbed out.

Also build-targets and dev-targets are still build-and-dev-targets on the assumption that those still being split up was a typo (feel free to convince me otherwise).