### PR TITLE
HACK: vaguely try to distinguish dev-deps to die on cycles less

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,8 @@ fn main() -> Result<(), VetError> {
         }
     };
 
-    trace!("Got Metadata! {:#?}", metadata);
+    trace!("Got Metadata!");
+    // trace!("Got Metadata! {:#?}", metadata);
 
     //////////////////////////////////////////////////////
     // Parse out our own configuration


### PR DESCRIPTION
I don't really like this specific implementation because it's not really rigorous/robust, but if you want to just unblock wasm-time you can use this as a temporary fix.