### PR TITLE
Resolver v3

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,8 +1,8 @@
 use core::fmt;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;
 
-use cargo_metadata::{Metadata, Node, Package, PackageId, Version};
+use cargo_metadata::{DependencyKind, Metadata, Node, PackageId, Version};
 use log::{error, trace, warn};
 
 use crate::format::{self, AuditKind, Delta};
@@ -16,14 +16,14 @@ pub struct Report<'a> {
     unaudited_count: u64,
     partially_audited_count: u64,
     fully_audited_count: u64,
-    useless_unaudited: Vec<&'a Package>,
+    useless_unaudited: Vec<PackageIdx>,
     /// These packages are the roots of the graph that transitively failed.
-    root_failures: Vec<&'a PackageId>,
+    root_failures: Vec<PackageIdx>,
     /// These packages are to blame and need to be fixed
-    leaf_failures: BTreeMap<&'a PackageId, AuditFailure>,
+    leaf_failures: BTreeMap<PackageIdx, AuditFailure>,
     results: Vec<ResolveResult<'a>>,
     graph: DepGraph<'a>,
-    violation_failed: Vec<&'a Package>,
+    violation_failed: Vec<PackageIdx>,
     criteria_mapper: CriteriaMapper,
 }
 
@@ -44,18 +44,32 @@ pub struct CriteriaMapper {
     implied_criteria: Vec<CriteriaSet>,
 }
 
+type PackageIdx = usize;
+
+#[derive(Debug, Clone)]
+pub struct PackageNode<'a> {
+    pub build_type: DependencyKind,
+    pub package_id: &'a PackageId,
+    pub name: &'a str,
+    pub version: &'a Version,
+    pub normal_deps: Vec<PackageIdx>,
+    pub build_deps: Vec<PackageIdx>,
+    pub dev_deps: Vec<PackageIdx>,
+    pub all_deps: Vec<PackageIdx>,
+    pub reverse_deps: HashSet<PackageIdx>,
+    pub is_workspace_member: bool,
+    pub is_third_party: bool,
+    pub is_root: bool,
+    pub has_non_dev_reverse_deps: bool,
+}
+
 /// The dependency graph in a form we can use more easily.
 #[derive(Debug, Clone)]
 pub struct DepGraph<'a> {
-    pub package_list: &'a [Package],
-    pub resolve_list: &'a [cargo_metadata::Node],
-    /// child -> parents in resolve
-    pub reverse_deps: BTreeMap<&'a PackageId, BTreeSet<&'a PackageId>>,
-    pub package_index_by_pkgid: BTreeMap<&'a PackageId, usize>,
-    pub resolve_index_by_pkgid: BTreeMap<&'a PackageId, usize>,
-    pub pkgid_by_name_and_ver: HashMap<&'a str, HashMap<&'a Version, &'a PackageId>>,
-    /// Toplogical sorting of the dependencies (linear iteration will do things in dependency order)
-    pub topo_index: Vec<&'a PackageId>,
+    pub nodes: Vec<PackageNode<'a>>,
+    pub interner_by_pkgid: BTreeMap<&'a PackageId, PackageIdx>,
+    pub interner_by_name_and_ver: BTreeMap<&'a str, BTreeMap<&'a Version, PackageIdx>>,
+    pub topo_index: Vec<PackageIdx>,
 }
 
 /// Results and notes from running vet on a particular package.
@@ -75,7 +89,7 @@ pub struct ResolveResult<'a> {
     pub needed_unaudited: bool,
 }
 
-pub type PolicyFailures<'a> = BTreeMap<&'a PackageId, CriteriaSet>;
+pub type PolicyFailures<'a> = BTreeMap<PackageIdx, CriteriaSet>;
 
 #[derive(Default, Debug, Clone)]
 pub struct AuditFailure {
@@ -98,7 +112,7 @@ pub enum SearchResult<'a> {
         /// This is currently overbroad in corner cases where there are two possible
         /// paths blocked by two different dependencies and so only fixing one would
         /// actually be sufficient, but, whatever.
-        failed_deps: BTreeSet<&'a PackageId>,
+        failed_deps: BTreeSet<PackageIdx>,
     },
     /// We failed to find any path, criteria not valid.
     Disconnected {
@@ -345,11 +359,6 @@ impl ResolveResult<'_> {
 
 impl<'a> DepGraph<'a> {
     pub fn new(metadata: &'a Metadata) -> Self {
-        // FIXME: study the nature of the 'resolve' field more carefully.
-        // In particular how resolver version 2 describes normal vs build/dev-deps.
-        // Worst case we might need to invoke 'cargo metadata' multiple times to get
-        // the proper description of both situations.
-
         let package_list = &*metadata.packages;
         let resolve_list = &*metadata
             .resolve
@@ -360,80 +369,185 @@ impl<'a> DepGraph<'a> {
             .iter()
             .enumerate()
             .map(|(idx, pkg)| (&pkg.id, idx))
-            .collect();
+            .collect::<BTreeMap<_, _>>();
         let resolve_index_by_pkgid = resolve_list
             .iter()
             .enumerate()
             .map(|(idx, pkg)| (&pkg.id, idx))
             .collect();
-        let mut pkgid_by_name_and_ver = HashMap::<&str, HashMap<&Version, &PackageId>>::new();
-        for pkg in package_list {
-            pkgid_by_name_and_ver
-                .entry(&*pkg.name)
-                .or_default()
-                .insert(&pkg.version, &pkg.id);
-        }
 
-        let mut reverse_deps = BTreeMap::<&PackageId, BTreeSet<&PackageId>>::new();
-        for parent in resolve_list {
-            for child in &parent.dependencies {
-                reverse_deps.entry(child).or_default().insert(&parent.id);
-            }
+        // Do a first-pass where we populate skeletons of the primary nodes
+        // and setup the interners, which will only ever refer to these nodes
+        let mut interner_by_pkgid = BTreeMap::<&PackageId, PackageIdx>::new();
+        let mut interner_by_name_and_ver = BTreeMap::<&str, BTreeMap<&Version, PackageIdx>>::new();
+        let mut nodes = vec![];
+        for resolve_node in resolve_list {
+            let idx = nodes.len();
+            let package = &package_list[package_index_by_pkgid[&resolve_node.id]];
+            nodes.push(PackageNode {
+                build_type: DependencyKind::Normal,
+                package_id: &resolve_node.id,
+                name: &package.name,
+                version: &package.version,
+                is_third_party: package.is_third_party(),
+                // These will get computed later
+                normal_deps: vec![],
+                build_deps: vec![],
+                dev_deps: vec![],
+                all_deps: vec![],
+                reverse_deps: HashSet::new(),
+                is_workspace_member: false,
+                is_root: false,
+                has_non_dev_reverse_deps: false,
+            });
+            assert!(interner_by_pkgid.insert(&resolve_node.id, idx).is_none());
+            assert!(interner_by_name_and_ver
+                .entry(&package.name)
+                .or_default()
+                .insert(&package.version, idx)
+                .is_none());
         }
 
         // Do topological sort: just recursively visit all of a node's children, and only add it
         // to the node *after* visiting the children. In this way we have trivially already added
         // all of the dependencies of a node by the time we have
-        let mut topo_index = Vec::with_capacity(package_list.len());
+
+        let mut topo_index = vec![];
         {
             // FIXME: cargo uses BTreeSet, PackageIds are long strings, so maybe this makes sense?
-            let mut visited = BTreeMap::new();
+            let mut visited = HashMap::new();
             // All of the roots can be found in the workspace_members.
             // It's fine if some aren't roots, toplogical sort works even if do all nodes.
             // FIXME: is it better to actually use resolve.root? Seems like it won't
             // work right for workspaces with multiple roots!
             for pkgid in &metadata.workspace_members {
+                let node_idx = interner_by_pkgid[pkgid];
+                nodes[node_idx].is_workspace_member = true;
                 visit_node(
+                    &mut nodes,
                     &mut topo_index,
                     &mut visited,
+                    &interner_by_pkgid,
+                    &interner_by_name_and_ver,
                     &resolve_index_by_pkgid,
                     resolve_list,
-                    pkgid,
+                    node_idx,
                 );
             }
             fn visit_node<'a>(
-                topo_index: &mut Vec<&'a PackageId>,
-                visited: &mut BTreeMap<&'a PackageId, ()>,
+                nodes: &mut Vec<PackageNode<'a>>,
+                topo_index: &mut Vec<PackageIdx>,
+                visited: &mut HashMap<PackageIdx, ()>,
+                interner_by_pkgid: &BTreeMap<&'a PackageId, PackageIdx>,
+                interner_by_name_and_ver: &BTreeMap<&'a str, BTreeMap<&'a Version, PackageIdx>>,
                 resolve_index_by_pkgid: &BTreeMap<&'a PackageId, usize>,
                 resolve_list: &'a [cargo_metadata::Node],
-                pkgid: &'a PackageId,
+                normal_idx: PackageIdx,
             ) {
-                // Don't revisit a node (fine for correctness, wasteful for perf)
-                let query = visited.entry(pkgid);
-                if matches!(query, std::collections::btree_map::Entry::Vacant(..)) {
+                // Don't revisit a node we've already seen
+                let query = visited.entry(normal_idx);
+                if matches!(query, std::collections::hash_map::Entry::Vacant(..)) {
                     query.or_insert(());
-                    let node = &resolve_list[resolve_index_by_pkgid[pkgid]];
-                    for child in &node.dependencies {
+                    let resolve_node =
+                        &resolve_list[resolve_index_by_pkgid[nodes[normal_idx].package_id]];
+
+                    // Compute the different kinds of dependencies
+                    let all_deps = resolve_node.dependencies.iter().map(|pkgid| interner_by_pkgid[pkgid]).collect::<Vec<_>>();
+                    let build_deps = deps(resolve_node, DependencyKind::Build, interner_by_pkgid);
+                    let normal_deps =
+                        deps(resolve_node, DependencyKind::Normal, interner_by_pkgid);
+                    let dev_deps =
+                        deps(resolve_node, DependencyKind::Development, interner_by_pkgid);
+
+                    // Now visit all the build deps
+                    for &child in &build_deps {
                         visit_node(
+                            nodes,
                             topo_index,
                             visited,
+                            interner_by_pkgid,
+                            interner_by_name_and_ver,
                             resolve_index_by_pkgid,
                             resolve_list,
                             child,
                         );
+                        nodes[child].reverse_deps.insert(normal_idx);
+                        nodes[child].has_non_dev_reverse_deps = true;
                     }
-                    topo_index.push(pkgid);
+
+                    // Now visit all the normal deps
+                    for &child in &normal_deps {
+                        visit_node(
+                            nodes,
+                            topo_index,
+                            visited,
+                            interner_by_pkgid,
+                            interner_by_name_and_ver,
+                            resolve_index_by_pkgid,
+                            resolve_list,
+                            child,
+                        );
+                        nodes[child].reverse_deps.insert(normal_idx);
+                        nodes[child].has_non_dev_reverse_deps = true;
+                    }
+
+                    // Now visit the node itself
+                    topo_index.push(normal_idx);
+
+                    // Now visit all the dev deps
+                    for &child in &dev_deps {
+                        visit_node(
+                            nodes,
+                            topo_index,
+                            visited,
+                            interner_by_pkgid,
+                            interner_by_name_and_ver,
+                            resolve_index_by_pkgid,
+                            resolve_list,
+                            child,
+                        );
+                        nodes[child].reverse_deps.insert(normal_idx);
+                        // NOTE: we don't set has_non_dev_reverse_deps here
+                        // so that we don't think things aren't roots just because
+                        // some tests import them.
+                    }
+
+                    // Now commit all the deps
+                    let cur_node = &mut nodes[normal_idx];
+                    cur_node.build_deps = build_deps;
+                    cur_node.normal_deps = normal_deps;
+                    cur_node.dev_deps = dev_deps;
+                    cur_node.all_deps = all_deps;
                 }
+            }
+            fn deps(
+                resolve_node: &Node,
+                kind: DependencyKind,
+                interner_by_pkgid: &BTreeMap<&PackageId, PackageIdx>,
+            ) -> Vec<PackageIdx> {
+                // Note that dep_kinds has target cfg info. If we want to handle targets
+                // we should gather those up with filter/fold instead of just 'any'.
+                // TODO: map normal-deps that whose package has a "proc-macro" target to be build-deps
+                resolve_node
+                    .deps
+                    .iter()
+                    .filter(|dep| dep.dep_kinds.iter().any(|dep_kind| dep_kind.kind == kind))
+                    .map(|dep| interner_by_pkgid[&dep.pkg])
+                    .collect()
             }
         }
 
+        // Now that we've visited the whole graph, mark the nodes that are workspace members
+        for pkgid in &metadata.workspace_members {
+            let node = &mut nodes[interner_by_pkgid[pkgid]];
+            node.is_workspace_member = true;
+            node.is_root = !node.has_non_dev_reverse_deps;
+        }
+
         Self {
-            package_list,
-            resolve_list,
-            reverse_deps,
-            package_index_by_pkgid,
-            resolve_index_by_pkgid,
-            pkgid_by_name_and_ver,
+            interner_by_pkgid,
+            interner_by_name_and_ver,
+            nodes,
             topo_index,
         }
     }
@@ -461,18 +575,14 @@ pub fn resolve<'a>(
     let criteria_mapper = CriteriaMapper::new(&audits.criteria);
 
     // This uses the same indexing pattern as graph.resolve_index_by_pkgid
-    let mut results = vec![
-        ResolveResult::with_no_criteria(criteria_mapper.no_criteria());
-        graph.resolve_list.len()
-    ];
+    let mut results =
+        vec![ResolveResult::with_no_criteria(criteria_mapper.no_criteria()); graph.nodes.len()];
     let mut root_failures = vec![];
     // Actually vet the dependencies
-    for pkgid in &graph.topo_index {
-        let resolve_idx = graph.resolve_index_by_pkgid[pkgid];
-        let resolve = &graph.resolve_list[resolve_idx];
-        let package = &graph.package_list[graph.package_index_by_pkgid[pkgid]];
+    for &pkgidx in &graph.topo_index {
+        let node = &graph.nodes[pkgidx];
 
-        if package.is_third_party() {
+        if node.is_third_party {
             resolve_third_party(
                 metadata,
                 config,
@@ -483,9 +593,7 @@ pub fn resolve<'a>(
                 &mut results,
                 &mut violation_failed,
                 &mut root_failures,
-                resolve_idx,
-                resolve,
-                package,
+                pkgidx,
             );
         } else {
             resolve_first_party(
@@ -498,9 +606,7 @@ pub fn resolve<'a>(
                 &mut results,
                 &mut violation_failed,
                 &mut root_failures,
-                resolve_idx,
-                resolve,
-                package,
+                pkgidx,
             );
         }
     }
@@ -522,7 +628,7 @@ pub fn resolve<'a>(
     }
 
     // Gather statistics
-    let mut leaf_failures = BTreeMap::<&PackageId, AuditFailure>::new();
+    let mut leaf_failures = BTreeMap::<PackageIdx, AuditFailure>::new();
     visit_failures(
         &graph,
         &results,
@@ -545,12 +651,11 @@ pub fn resolve<'a>(
     let mut fully_audited_count = 0;
     let mut partially_audited_count = 0;
     let mut useless_unaudited = vec![];
-    for &pkgid in &graph.topo_index {
-        let resolve_idx = graph.resolve_index_by_pkgid[pkgid];
-        let package = &graph.package_list[graph.package_index_by_pkgid[pkgid]];
-        let result = &results[resolve_idx];
+    for &pkgidx in &graph.topo_index {
+        let node = &graph.nodes[pkgidx];
+        let result = &results[pkgidx];
 
-        if !result.needed_unaudited || !package.is_third_party() {
+        if !result.needed_unaudited || !node.is_third_party {
             fully_audited_count += 1;
         } else if result.directly_unaudited {
             unaudited_count += 1;
@@ -559,7 +664,7 @@ pub fn resolve<'a>(
         }
 
         if result.directly_unaudited && !result.needed_unaudited {
-            useless_unaudited.push(package);
+            useless_unaudited.push(pkgidx);
         }
     }
 
@@ -586,20 +691,19 @@ fn resolve_third_party<'a>(
     graph: &DepGraph<'a>,
     criteria_mapper: &CriteriaMapper,
     results: &mut [ResolveResult<'a>],
-    violation_failed: &mut Vec<&'a Package>,
-    _root_failures: &mut Vec<&'a PackageId>,
-    resolve_idx: usize,
-    resolve: &'a Node,
-    package: &'a Package,
+    violation_failed: &mut Vec<PackageIdx>,
+    _root_failures: &mut Vec<PackageIdx>,
+    pkgidx: PackageIdx,
 ) {
-    let unaudited = config.unaudited.get(&package.name);
+    let package = &graph.nodes[pkgidx];
+    let unaudited = config.unaudited.get(package.name);
 
     // Just merge all the entries from the foreign audit files and our audit file.
     let foreign_audits = imports
         .audits
         .values()
-        .flat_map(|audit_file| audit_file.audits.get(&package.name).unwrap_or(&NO_AUDITS));
-    let own_audits = audits.audits.get(&package.name).unwrap_or(&NO_AUDITS);
+        .flat_map(|audit_file| audit_file.audits.get(package.name).unwrap_or(&NO_AUDITS));
+    let own_audits = audits.audits.get(package.name).unwrap_or(&NO_AUDITS);
 
     // Deltas are flipped so that we have a map of 'to: [froms]'. This lets
     // us start at the current version and look up all the deltas that *end* at that
@@ -667,7 +771,7 @@ fn resolve_third_party<'a>(
 
         for entry in foreign_audits
             .audits
-            .get(&package.name)
+            .get(package.name)
             .unwrap_or(&NO_AUDITS)
         {
             // For uniformity, model a Full Audit as `0.0.0 -> x.y.z`
@@ -759,8 +863,8 @@ fn resolve_third_party<'a>(
         }
         // Having current versions overlap with a violations is less horrifyingly bad,
         // so just gather them up as part of the normal report.
-        if violation_range.matches(&package.version) {
-            violation_failed.push(package);
+        if violation_range.matches(package.version) {
+            violation_failed.push(pkgidx);
             return;
         }
     }
@@ -773,7 +877,7 @@ fn resolve_third_party<'a>(
     // Also register all the unaudited entries as "roots" for search.
     if let Some(alloweds) = unaudited {
         for allowed in alloweds {
-            if allowed.version == package.version {
+            if &allowed.version == package.version {
                 directly_unaudited = true;
             }
             let from_ver = &ROOT_VERSION;
@@ -806,7 +910,7 @@ fn resolve_third_party<'a>(
             &package.version,
             &forward_nodes,
             graph,
-            resolve,
+            package,
             results,
         );
         match result {
@@ -835,7 +939,7 @@ fn resolve_third_party<'a>(
                     &ROOT_VERSION,
                     &backward_nodes,
                     graph,
-                    resolve,
+                    package,
                     results,
                 );
                 if let SearchResult::Disconnected {
@@ -855,7 +959,7 @@ fn resolve_third_party<'a>(
     }
 
     // We've completed our graph analysis for this package, now record the results
-    results[resolve_idx] = ResolveResult {
+    results[pkgidx] = ResolveResult {
         validated_criteria,
         fully_audited_criteria,
         directly_unaudited,
@@ -868,46 +972,43 @@ fn resolve_third_party<'a>(
 
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 fn resolve_first_party<'a>(
-    metadata: &'a Metadata,
+    _metadata: &'a Metadata,
     config: &'a ConfigFile,
     _audits: &'a AuditsFile,
     _imports: &'a ImportsFile,
     graph: &DepGraph<'a>,
     criteria_mapper: &CriteriaMapper,
     results: &mut [ResolveResult<'a>],
-    _violation_failed: &mut Vec<&'a Package>,
-    root_failures: &mut Vec<&'a PackageId>,
-    resolve_idx: usize,
-    resolve: &'a Node,
-    package: &'a Package,
+    _violation_failed: &mut Vec<PackageIdx>,
+    root_failures: &mut Vec<PackageIdx>,
+    pkgidx: PackageIdx,
 ) {
     // Compute the "policy" criteria
+    let package = &graph.nodes[pkgidx];
 
     let default_root_policy = criteria_mapper.criteria_from_list([format::DEFAULT_POLICY_CRITERIA]);
     let _default_build_and_dev_policy =
         criteria_mapper.criteria_from_list([format::DEFAULT_POLICY_BUILD_AND_DEV_CRITERIA]);
 
-    let is_root = metadata.workspace_members.contains(&package.id);
     let mut policy_failures = PolicyFailures::new();
 
     // Any dependencies that have explicit policies are checked first
     let mut passed_dependencies = BTreeSet::new();
-    if let Some(policy) = config.policy.get(&package.name) {
-        for dep in &resolve.dependencies {
-            let dep_resolve_idx = graph.resolve_index_by_pkgid[dep];
-            let dep_package = &graph.package_list[graph.package_index_by_pkgid[dep]];
+    if let Some(policy) = config.policy.get(package.name) {
+        for &depidx in &package.all_deps {
+            let dep_package = &graph.nodes[depidx];
             let dep_policy = policy
                 .dependency_criteria
-                .get(&dep_package.name)
+                .get(dep_package.name)
                 .map(|p| criteria_mapper.criteria_from_list(p))
                 .unwrap_or_else(|| criteria_mapper.no_criteria());
 
             for criteria_idx in dep_policy.indices() {
-                if results[dep_resolve_idx].has_criteria(criteria_idx) {
-                    passed_dependencies.insert(dep);
+                if results[depidx].has_criteria(criteria_idx) {
+                    passed_dependencies.insert(depidx);
                 } else {
                     policy_failures
-                        .entry(dep)
+                        .entry(depidx)
                         .or_insert_with(|| criteria_mapper.no_criteria())
                         .set_criteria(criteria_idx);
                 }
@@ -920,14 +1021,13 @@ fn resolve_first_party<'a>(
         let mut search_results = vec![];
         for criteria in criteria_mapper.criteria_iter() {
             let mut failed_deps = BTreeSet::new();
-            for dep in &resolve.dependencies {
-                if passed_dependencies.contains(dep) {
+            for &depidx in &package.all_deps {
+                if passed_dependencies.contains(&depidx) {
                     // This dep is already fine, ignore it (implicitly all_criteria now)
                     continue;
                 }
-                let dep_resolve_idx = graph.resolve_index_by_pkgid[dep];
-                if !results[dep_resolve_idx].contains(criteria) {
-                    failed_deps.insert(dep);
+                if !results[depidx].contains(criteria) {
+                    failed_deps.insert(depidx);
                 }
             }
 
@@ -942,9 +1042,9 @@ fn resolve_first_party<'a>(
         }
 
         // Now check that we pass our own policy
-        let own_policy = if let Some(policy) = config.policy.get(&package.name) {
+        let own_policy = if let Some(policy) = config.policy.get(package.name) {
             criteria_mapper.criteria_from_list(&policy.criteria)
-        } else if is_root {
+        } else if package.is_root {
             default_root_policy
         } else {
             criteria_mapper.no_criteria()
@@ -962,15 +1062,15 @@ fn resolve_first_party<'a>(
         }
 
         if policy_failures.is_empty() {
-            results[resolve_idx].search_results = search_results;
-            results[resolve_idx].validated_criteria = validated_criteria;
+            results[pkgidx].search_results = search_results;
+            results[pkgidx].validated_criteria = validated_criteria;
         }
     }
 
-    if !policy_failures.is_empty() && is_root {
-        root_failures.push(&package.id);
+    if !policy_failures.is_empty() && package.is_root {
+        root_failures.push(pkgidx);
     }
-    results[resolve_idx].policy_failures = policy_failures;
+    results[pkgidx].policy_failures = policy_failures;
 }
 
 fn search_for_path<'a>(
@@ -979,7 +1079,7 @@ fn search_for_path<'a>(
     to_version: &'a Version,
     version_nodes: &BTreeMap<&'a Version, Vec<DeltaEdge<'a>>>,
     dep_graph: &DepGraph<'a>,
-    resolve: &'a Node,
+    package: &PackageNode<'a>,
     results: &mut [ResolveResult],
 ) -> SearchResult<'a> {
     // Search for any path through the graph with edges that satisfy cur_criteria.
@@ -1066,12 +1166,10 @@ fn search_for_path<'a>(
 
                     // Deltas should only apply if dependencies satisfy dep_criteria
                     let mut deps_satisfied = true;
-                    for dependency in &resolve.dependencies {
-                        let dep_resolve_idx = dep_graph.resolve_index_by_pkgid[dependency];
-                        let dep_package =
-                            &dep_graph.package_list[dep_graph.package_index_by_pkgid[dependency]];
-                        let dep_vet_result = &mut results[dep_resolve_idx];
-
+                    for &dependency in &package.all_deps {
+                        let dep_package = &dep_graph.nodes[dependency];
+                        let dep_vet_result = &mut results[dependency];
+                         
                         // If no custom criteria is specified, then require our dependency to match
                         // the same criteria that this delta claims to provide.
                         // e.g. a 'secure' audit requires all dependencies to be 'secure' by default.
@@ -1161,7 +1259,8 @@ impl<'a> Report<'a> {
                 out,
                 "  warning: some dependencies are listed in unaudited, but didn't need it:"
             )?;
-            for package in &self.useless_unaudited {
+            for &pkgidx in &self.useless_unaudited {
+                let package = &self.graph.nodes[pkgidx];
                 writeln!(out, "    {}:{}", package.name, package.version)?;
             }
         }
@@ -1174,9 +1273,10 @@ impl<'a> Report<'a> {
         writeln!(out)?;
         if !self.root_failures.is_empty() {
             writeln!(out, "{} unvetted dependencies:", self.leaf_failures.len())?;
-            for (failed, failed_audit) in &self.leaf_failures {
-                let failed_package =
-                    &self.graph.package_list[self.graph.package_index_by_pkgid[failed]];
+            let  mut failures = self.leaf_failures.iter().map(|(&failed_idx, failure)| (&self.graph.nodes[failed_idx], failure)).collect::<Vec<_>>();
+            failures.sort_by_key(|(failed, _)| failed.version);
+            failures.sort_by_key(|(failed, _)| failed.name);
+            for (failed_package, failed_audit) in failures {
                 let criteria = self
                     .criteria_mapper
                     .criteria_names(&failed_audit.criteria_failures)
@@ -1196,7 +1296,8 @@ impl<'a> Report<'a> {
                 "{} forbidden dependencies:",
                 self.violation_failed.len()
             )?;
-            for package in &self.violation_failed {
+            for &pkgidx in &self.violation_failed {
+                let package = &self.graph.nodes[pkgidx];
                 writeln!(out, "  {}:{}", package.name, package.version)?;
             }
             writeln!(out)?;
@@ -1212,7 +1313,7 @@ impl<'a> Report<'a> {
         }
 
         struct SuggestItem<'a> {
-            package: &'a Package,
+            package: &'a PackageNode<'a>,
             rec: DiffRecommendation,
             criteria: String,
             parents: String,
@@ -1221,10 +1322,9 @@ impl<'a> Report<'a> {
         let mut cache = Cache::acquire(cfg)?;
         let mut suggestions = vec![];
         let mut total_lines: u64 = 0;
-        for (failure, audit_failure) in &self.leaf_failures {
-            let package = &self.graph.package_list[self.graph.package_index_by_pkgid[failure]];
-            let resolve_idx = self.graph.resolve_index_by_pkgid[failure];
-            let result = &self.results[resolve_idx];
+        for (&failure_idx, audit_failure) in &self.leaf_failures {
+            let package = &self.graph.nodes[failure_idx];
+            let result = &self.results[failure_idx];
 
             // Collect up the details of how we failed
             let mut from_root = None::<BTreeSet<&Version>>;
@@ -1292,16 +1392,19 @@ impl<'a> Report<'a> {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            let mut reverse_deps = self.graph.reverse_deps[failure]
+            let mut reverse_deps = self.graph.nodes[failure_idx].reverse_deps
                 .iter()
-                .map(|parent| {
-                    self.graph.package_list[self.graph.package_index_by_pkgid[parent]]
+                .map(|&parent| {
+                    self.graph.nodes[parent]
                         .name
-                        .clone()
+                        .to_string()
                 })
                 .collect::<Vec<_>>();
 
             // To keep the display compact, sort by name length and truncate long lists.
+            // We first sort by name because rust defaults to a stable sort and this will
+            // have by-name as the tie breaker.
+            reverse_deps.sort();
             reverse_deps.sort_by_key(|item| item.len());
             let cutoff_index = reverse_deps
                 .iter()
@@ -1337,6 +1440,8 @@ impl<'a> Report<'a> {
             }
         }
 
+        suggestions.sort_by_key(|item| item.package.version);
+        suggestions.sort_by_key(|item| item.package.name);
         suggestions.sort_by_key(|item| item.rec.diffstat.count);
         let mut by_criteria = BTreeMap::new();
         for s in suggestions.into_iter() {
@@ -1400,9 +1505,9 @@ impl<'a> Report<'a> {
 fn visit_failures<'a, T>(
     graph: &DepGraph<'a>,
     results: &[ResolveResult<'a>],
-    failures: &[&'a PackageId],
+    failures: &[PackageIdx],
     guess_deeper: bool,
-    mut callback: impl FnMut(&'a PackageId, usize, Option<&CriteriaSet>) -> Result<(), T>,
+    mut callback: impl FnMut(PackageIdx, usize, Option<&CriteriaSet>) -> Result<(), T>,
 ) -> Result<(), T> {
     trace!("blame: traversing blame tree");
 
@@ -1437,15 +1542,15 @@ fn visit_failures<'a, T>(
     // but I want to think about this more. For now we just rely on the solution to problem 2
     // to avoid infinite loops and just don't worry about the semantics.
     let mut search_stack = failures.iter().map(|f| (*f, 0, None)).collect::<Vec<_>>();
-    let mut visited = BTreeMap::<&PackageId, CriteriaSet>::new();
+    let mut visited = HashMap::<PackageIdx, CriteriaSet>::new();
     let no_criteria = CriteriaSet::default();
 
-    while let Some((failure, depth, cur_criteria)) = search_stack.pop() {
-        match visited.entry(failure) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
+    while let Some((failure_idx, depth, cur_criteria)) = search_stack.pop() {
+        match visited.entry(failure_idx) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(cur_criteria.clone().unwrap_or_else(|| no_criteria.clone()));
             }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let cur = cur_criteria.as_ref().unwrap_or(&no_criteria);
                 if entry.get().contains(cur) {
                     continue;
@@ -1455,10 +1560,8 @@ fn visit_failures<'a, T>(
             }
         }
 
-        let resolve_idx = graph.resolve_index_by_pkgid[failure];
-        let resolve = &graph.resolve_list[resolve_idx];
-        let result = &results[resolve_idx];
-        let package = &graph.package_list[graph.package_index_by_pkgid[failure]];
+        let result = &results[failure_idx];
+        let package = &graph.nodes[failure_idx];
         trace!(
             "blame: {:width$}visiting {}:{}",
             "",
@@ -1469,14 +1572,14 @@ fn visit_failures<'a, T>(
 
         if !result.policy_failures.is_empty() {
             // We're not to blame, it's our children who failed our policies!
-            callback(failure, depth, None)?;
-            for (failed_dep, failed_criteria) in &result.policy_failures {
+            callback(failure_idx, depth, None)?;
+            for (&failed_dep, failed_criteria) in &result.policy_failures {
                 search_stack.push((failed_dep, depth + 1, Some(failed_criteria.clone())));
             }
         } else if let Some(failed_criteria) = cur_criteria {
             let mut own_fault = CriteriaSet::default();
-            let mut dep_faults = BTreeMap::<&PackageId, CriteriaSet>::new();
-            let mut deeper_faults = BTreeMap::<&PackageId, CriteriaSet>::new();
+            let mut dep_faults = BTreeMap::<PackageIdx, CriteriaSet>::new();
+            let mut deeper_faults = BTreeMap::<PackageIdx, CriteriaSet>::new();
 
             // Collect up details of how we failed the criteria
             for criteria_idx in failed_criteria.indices() {
@@ -1500,12 +1603,11 @@ fn visit_failures<'a, T>(
                         if guess_deeper {
                             // Try to Guess Deeper by blaming our children for all |self| failures
                             // by assuming we would need them to conform to our own criteria too.
-                            for dep in &resolve.dependencies {
-                                let dep_resolve_idx = graph.resolve_index_by_pkgid[dep];
-                                let dep_result = &results[dep_resolve_idx];
+                            for &dep_idx in &package.all_deps {
+                                let dep_result = &results[dep_idx];
                                 if !dep_result.validated_criteria.has_criteria(criteria_idx) {
                                     deeper_faults
-                                        .entry(dep)
+                                        .entry(dep_idx)
                                         .or_default()
                                         .set_criteria(criteria_idx);
                                 }
@@ -1517,14 +1619,14 @@ fn visit_failures<'a, T>(
 
             // Visit ourselves based on whether we're to blame at all
             if own_fault.is_empty() {
-                callback(failure, depth, None)?;
+                callback(failure_idx, depth, None)?;
             } else {
-                callback(failure, depth, Some(&own_fault))?;
+                callback(failure_idx, depth, Some(&own_fault))?;
             }
 
             // Now visit our children
             for (failed_dep, failed_criteria) in deeper_faults {
-                if dep_faults.contains_key(failed_dep) {
+                if dep_faults.contains_key(&failed_dep) {
                     // We already visited them more precisely
                     continue;
                 }

--- a/src/snapshots/cargo_vet__tests__builtin-cycle-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-cycle-full-audited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 2024
+expression: stdout
+---
+Vetting Succeeded (2 fully audited)
+

--- a/src/snapshots/cargo_vet__tests__builtin-cycle-inited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-cycle-inited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1994
+expression: stdout
+---
+Vetting Succeeded (2 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__builtin-cycle-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-cycle-unaudited.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests.rs
+assertion_line: 2009
+expression: stdout
+---
+Vetting Failed!
+
+2 unvetted dependencies:
+  dev-cycle:10.0.0 missing ["safe-to-run"]
+  normal:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect normal 10.0.0  (used by root)  (100 lines)
+
+recommended audits for safe-to-run:
+    cargo vet inspect dev-cycle 10.0.0  (used by root)  (100 lines)
+
+estimated audit backlog: 200 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/snapshots/cargo_vet__tests__builtin-no-deps.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-no-deps.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1932
+expression: stdout
+---
+Vetting Succeeded (because you have no third-party dependencies)
+

--- a/src/snapshots/cargo_vet__tests__builtin-only-first-deps.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-only-first-deps.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1960
+expression: stdout
+---
+Vetting Succeeded (because you have no third-party dependencies)
+

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1900
+assertion_line: 1910
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (7 fully audited, 0 partially audited, 0 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
@@ -3,5 +3,5 @@ source: src/tests.rs
 assertion_line: 1910
 expression: stdout
 ---
-Vetting Succeeded (7 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (6 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
@@ -3,9 +3,5 @@ source: src/tests.rs
 assertion_line: 1900
 expression: stdout
 ---
-Vetting Failed!
-
-0 unvetted dependencies:
-
-nothing to recommend
+Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-full-audited.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests.rs
+assertion_line: 1900
+expression: stdout
+---
+Vetting Failed!
+
+0 unvetted dependencies:
+
+nothing to recommend
+

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1870
+assertion_line: 1880
 expression: stdout
 ---
-Vetting Succeeded (1 fully audited, 0 partially audited, 4 unaudited)
+Vetting Succeeded (1 fully audited, 0 partially audited, 6 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
@@ -3,5 +3,5 @@ source: src/tests.rs
 assertion_line: 1880
 expression: stdout
 ---
-Vetting Succeeded (1 fully audited, 0 partially audited, 6 unaudited)
+Vetting Succeeded (6 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests.rs
+assertion_line: 1870
+expression: stdout
+---
+Vetting Failed!
+
+0 unvetted dependencies:
+
+nothing to recommend
+

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-init.snap
@@ -3,9 +3,5 @@ source: src/tests.rs
 assertion_line: 1870
 expression: stdout
 ---
-Vetting Failed!
-
-0 unvetted dependencies:
-
-nothing to recommend
+Vetting Succeeded (1 fully audited, 0 partially audited, 4 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests.rs
+assertion_line: 1885
+expression: stdout
+---
+Vetting Failed!
+
+4 unvetted dependencies:
+  build:10.0.0 missing ["safe-to-deploy"]
+  dev:10.0.0 missing ["safe-to-deploy"]
+  normal:10.0.0 missing ["safe-to-deploy"]
+  proc-macro:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect build 10.0.0       (used by root)  (100 lines)
+    cargo vet inspect dev 10.0.0         (used by root)  (100 lines)
+    cargo vet inspect normal 10.0.0      (used by root)  (100 lines)
+    cargo vet inspect proc-macro 10.0.0  (used by root)  (100 lines)
+
+estimated audit backlog: 400 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
@@ -1,25 +1,29 @@
 ---
 source: src/tests.rs
-assertion_line: 1885
+assertion_line: 1895
 expression: stdout
 ---
 Vetting Failed!
 
-4 unvetted dependencies:
+6 unvetted dependencies:
   build:10.0.0 missing ["safe-to-deploy"]
+  build-proc-macro:10.0.0 missing ["safe-to-deploy"]
   dev:10.0.0 missing ["safe-to-run"]
+  dev-proc-macro:10.0.0 missing ["safe-to-run"]
   normal:10.0.0 missing ["safe-to-deploy"]
   proc-macro:10.0.0 missing ["safe-to-deploy"]
 
 recommended audits for safe-to-deploy:
-    cargo vet inspect build 10.0.0       (used by root)  (100 lines)
-    cargo vet inspect normal 10.0.0      (used by root)  (100 lines)
-    cargo vet inspect proc-macro 10.0.0  (used by root)  (100 lines)
+    cargo vet inspect build 10.0.0             (used by root)  (100 lines)
+    cargo vet inspect build-proc-macro 10.0.0  (used by root)  (100 lines)
+    cargo vet inspect normal 10.0.0            (used by root)  (100 lines)
+    cargo vet inspect proc-macro 10.0.0        (used by root)  (100 lines)
 
 recommended audits for safe-to-run:
-    cargo vet inspect dev 10.0.0  (used by root)  (100 lines)
+    cargo vet inspect dev 10.0.0             (used by root)  (100 lines)
+    cargo vet inspect dev-proc-macro 10.0.0  (used by root)  (100 lines)
 
-estimated audit backlog: 400 lines
+estimated audit backlog: 600 lines
 
 Use |cargo vet certify| to record the audits.
 

--- a/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__builtin-simple-deps-no-unaudited.snap
@@ -7,15 +7,17 @@ Vetting Failed!
 
 4 unvetted dependencies:
   build:10.0.0 missing ["safe-to-deploy"]
-  dev:10.0.0 missing ["safe-to-deploy"]
+  dev:10.0.0 missing ["safe-to-run"]
   normal:10.0.0 missing ["safe-to-deploy"]
   proc-macro:10.0.0 missing ["safe-to-deploy"]
 
 recommended audits for safe-to-deploy:
     cargo vet inspect build 10.0.0       (used by root)  (100 lines)
-    cargo vet inspect dev 10.0.0         (used by root)  (100 lines)
     cargo vet inspect normal 10.0.0      (used by root)  (100 lines)
     cargo vet inspect proc-macro 10.0.0  (used by root)  (100 lines)
+
+recommended audits for safe-to-run:
+    cargo vet inspect dev 10.0.0  (used by root)  (100 lines)
 
 estimated audit backlog: 400 lines
 

--- a/src/snapshots/cargo_vet__tests__mock-builtin-complex-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-complex-full-audited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1425
+assertion_line: 1465
 expression: stdout
 ---
-Vetting Succeeded (10 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (4 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-builtin-complex-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-complex-full-audited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1425
+expression: stdout
+---
+Vetting Succeeded (10 fully audited, 0 partially audited, 0 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__mock-builtin-complex-inited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-complex-inited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1399
+expression: stdout
+---
+Vetting Succeeded (6 fully audited, 0 partially audited, 4 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__mock-builtin-complex-inited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-complex-inited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1399
+assertion_line: 1439
 expression: stdout
 ---
-Vetting Succeeded (6 fully audited, 0 partially audited, 4 unaudited)
+Vetting Succeeded (4 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__mock-builtin-complex-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-complex-no-unaudited.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests.rs
+assertion_line: 1412
+expression: stdout
+---
+Vetting Failed!
+
+4 unvetted dependencies:
+  third-core:5.0.0 missing ["safe-to-deploy"]
+  third-core:10.0.0 missing ["safe-to-deploy"]
+  thirdA:10.0.0 missing ["safe-to-deploy"]
+  thirdAB:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect third-core 5.0.0   (used by firstA)                   (25 lines)
+    cargo vet inspect third-core 10.0.0  (used by firstB, thirdA, thirdAB)  (100 lines)
+    cargo vet inspect thirdA 10.0.0      (used by firstA)                   (100 lines)
+    cargo vet inspect thirdAB 10.0.0     (used by firstAB)                  (100 lines)
+
+estimated audit backlog: 325 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/snapshots/cargo_vet__tests__mock-builtin-simple-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-simple-full-audited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 750
+assertion_line: 791
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-builtin-simple-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-simple-full-audited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 750
+expression: stdout
+---
+Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__mock-builtin-simple-init.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-simple-init.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 720
+expression: stdout
+---
+Vetting Succeeded (2 fully audited, 0 partially audited, 3 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__mock-builtin-simple-init.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-simple-init.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 720
+assertion_line: 761
 expression: stdout
 ---
-Vetting Succeeded (2 fully audited, 0 partially audited, 3 unaudited)
+Vetting Succeeded (3 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__mock-builtin-simple-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-builtin-simple-no-unaudited.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests.rs
+assertion_line: 735
+expression: stdout
+---
+Vetting Failed!
+
+2 unvetted dependencies:
+  third-party1:10.0.0 missing ["safe-to-deploy"]
+  third-party2:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect third-party1 10.0.0  (used by first-party)  (100 lines)
+    cargo vet inspect third-party2 10.0.0  (used by first-party)  (100 lines)
+
+estimated audit backlog: 200 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/snapshots/cargo_vet__tests__mock-complex-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-complex-full-audited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1241
+assertion_line: 1426
 expression: stdout
 ---
-Vetting Succeeded (10 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (4 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-complex-inited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-complex-inited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1360
+assertion_line: 1400
 expression: stdout
 ---
-Vetting Succeeded (6 fully audited, 0 partially audited, 4 unaudited)
+Vetting Succeeded (4 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__mock-complex-inited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-complex-inited.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests.rs
+assertion_line: 1360
+expression: stdout
+---
+Vetting Succeeded (6 fully audited, 0 partially audited, 4 unaudited)
+

--- a/src/snapshots/cargo_vet__tests__mock-complex-no-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-complex-no-unaudited.snap
@@ -1,12 +1,13 @@
 ---
 source: src/tests.rs
+assertion_line: 1283
 expression: stdout
 ---
 Vetting Failed!
 
 4 unvetted dependencies:
-  third-core:10.0.0 missing ["reviewed"]
   third-core:5.0.0 missing ["reviewed"]
+  third-core:10.0.0 missing ["reviewed"]
   thirdA:10.0.0 missing ["reviewed"]
   thirdAB:10.0.0 missing ["reviewed"]
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-delta-to-full-audit.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-delta-to-full-audit.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 797
+assertion_line: 1127
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-delta-to-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-delta-to-unaudited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 712
+assertion_line: 1045
 expression: stdout
 ---
-Vetting Succeeded (4 fully audited, 1 partially audited, 0 unaudited)
+Vetting Succeeded (2 fully audited, 1 partially audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-full-audited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-full-audited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 414
+assertion_line: 747
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-init.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-init.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 380
+assertion_line: 717
 expression: stdout
 ---
-Vetting Succeeded (2 fully audited, 0 partially audited, 3 unaudited)
+Vetting Succeeded (3 unaudited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-reverse-delta-to-full-audit.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-reverse-delta-to-full-audit.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 872
+assertion_line: 1199
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-reverse-delta-to-unaudited.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-reverse-delta-to-unaudited.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 902
+assertion_line: 1228
 expression: stdout
 ---
-Vetting Succeeded (4 fully audited, 1 partially audited, 0 unaudited)
+Vetting Succeeded (2 fully audited, 1 partially audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-weaker-transitive-req-using-implies.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-weaker-transitive-req-using-implies.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 592
+assertion_line: 937
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__mock-simple-weaker-transitive-req.snap
+++ b/src/snapshots/cargo_vet__tests__mock-simple-weaker-transitive-req.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 553
+assertion_line: 909
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-dep-extra.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-dep-extra.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1629
+assertion_line: 1806
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-dep-stronger.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-dep-stronger.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1587
+assertion_line: 1763
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-dep-weaker-needed.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-dep-weaker-needed.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1606
+assertion_line: 1783
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-dep-weaker.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-dep-weaker.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1551
+assertion_line: 1725
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-policy-redundant.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-policy-redundant.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1689
+assertion_line: 1867
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-first-weaker.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-first-weaker.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1500
+assertion_line: 1671
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-root-dep-weaker.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-root-dep-weaker.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1517
+assertion_line: 1689
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/snapshots/cargo_vet__tests__simple-policy-root-weaker.snap
+++ b/src/snapshots/cargo_vet__tests__simple-policy-root-weaker.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests.rs
-assertion_line: 1466
+assertion_line: 1637
 expression: stdout
 ---
-Vetting Succeeded (5 fully audited, 0 partially audited, 0 unaudited)
+Vetting Succeeded (3 fully audited)
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -369,8 +369,8 @@ impl MockMetadata {
                 is_root: true,
                 is_first_party: true,
                 deps: vec![dep("normal"), dep("proc-macro")],
-                dev_deps: vec![dep("dev")],
-                build_deps: vec![dep("build")],
+                dev_deps: vec![dep("dev"), dep("dev-proc-macro")],
+                build_deps: vec![dep("build"), dep("build-proc-macro")],
                 ..Default::default()
             },
             MockPackage {
@@ -387,6 +387,16 @@ impl MockMetadata {
             },
             MockPackage {
                 name: "proc-macro",
+                targets: vec!["proc-macro"],
+                ..Default::default()
+            },
+            MockPackage {
+                name: "dev-proc-macro",
+                targets: vec!["proc-macro"],
+                ..Default::default()
+            },
+            MockPackage {
+                name: "build-proc-macro",
                 targets: vec!["proc-macro"],
                 ..Default::default()
             },

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use cargo_metadata::{Metadata, Version, VersionReq};
 use serde_json::{json, Value};
 
 use crate::{
-    format::{AuditKind, Delta, DependencyCriteria, MetaConfig, PolicyEntry},
+    format::{AuditKind, Delta, DependencyCriteria, MetaConfig, PolicyEntry, SAFE_TO_DEPLOY},
     init_files,
     resolver::Report,
     AuditEntry, AuditsFile, Cli, Config, ConfigFile, CriteriaEntry, ImportsFile, PackageExt,
@@ -27,6 +27,7 @@ struct MockPackage {
     deps: Vec<MockDependency>,
     dev_deps: Vec<MockDependency>,
     build_deps: Vec<MockDependency>,
+    targets: Vec<&'static str>,
     is_root: bool,
     is_first_party: bool,
 }
@@ -44,6 +45,7 @@ impl Default for MockPackage {
             deps: vec![],
             dev_deps: vec![],
             build_deps: vec![],
+            targets: vec!["lib"],
             is_root: false,
             is_first_party: false,
         }
@@ -358,6 +360,39 @@ impl MockMetadata {
             },
         ])
     }
+
+    fn simple_deps() -> Self {
+        // Different dependency cases
+        MockMetadata::new(vec![
+            MockPackage {
+                name: "root",
+                is_root: true,
+                is_first_party: true,
+                deps: vec![dep("normal"), dep("proc-macro")],
+                dev_deps: vec![dep("dev")],
+                build_deps: vec![dep("build")],
+                ..Default::default()
+            },
+            MockPackage {
+                name: "normal",
+                ..Default::default()
+            },
+            MockPackage {
+                name: "dev",
+                ..Default::default()
+            },
+            MockPackage {
+                name: "build",
+                ..Default::default()
+            },
+            MockPackage {
+                name: "proc-macro",
+                targets: vec!["proc-macro"],
+                ..Default::default()
+            },
+        ])
+    }
+
     fn new(packages: Vec<MockPackage>) -> Self {
         let mut pkgids = vec![];
         let mut idx_by_name_and_ver = BTreeMap::<&str, BTreeMap<Version, usize>>::new();
@@ -385,13 +420,6 @@ impl MockMetadata {
                 package.name,
                 package.version
             );
-
-            if !package.build_deps.is_empty() {
-                unimplemented!("build-deps aren't mockable yet");
-            }
-            if !package.dev_deps.is_empty() {
-                unimplemented!("dev-deps aren't mockable yet");
-            }
         }
 
         Self {
@@ -431,7 +459,7 @@ impl MockMetadata {
                 "license_file": null,
                 "description": "whatever",
                 "source": self.source(package),
-                "dependencies": package.deps.iter().map(|dep| json!({
+                "dependencies": package.deps.iter().chain(&package.dev_deps).chain(&package.build_deps).map(|dep| json!({
                     "name": dep.name,
                     "source": self.source(self.package_by(dep.name, &dep.version)),
                     "req": format!("={}", dep.version),
@@ -443,22 +471,20 @@ impl MockMetadata {
                     "target": null,
                     "registry": null
                 })).collect::<Vec<_>>(),
-                "targets": [
-                    {
-                        "kind": [
-                            "lib"
-                        ],
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "name": package.name,
-                        "src_path": "C:\\Users\\fake_user\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\DUMMY\\src\\lib.rs",
-                        "edition": "2015",
-                        "doc": true,
-                        "doctest": true,
-                        "test": true
-                    },
-                ],
+                "targets": package.targets.iter().map(|target| json!({
+                    "kind": [
+                        target
+                    ],
+                    "crate_types": [
+                        target
+                    ],
+                    "name": package.name,
+                    "src_path": "C:\\Users\\fake_user\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\DUMMY\\src\\lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                })).collect::<Vec<_>>(),
                 "features": {},
                 "manifest_path": "C:\\Users\\fake_user\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\DUMMY\\Cargo.toml",
                 "metadata": null,
@@ -483,22 +509,30 @@ impl MockMetadata {
                 }
             }).collect::<Vec<_>>(),
             "resolve": {
-                "nodes": self.packages.iter().map(|package| json!({
-                    "id": self.pkgid(package),
-                    "dependencies": package.deps.iter().map(|dep| {
-                        self.pkgid_by(dep.name, &dep.version)
-                    }).collect::<Vec<_>>(),
-                    "deps": package.deps.iter().map(|dep| json!({
-                        "name": dep.name,
-                        "pkg": self.pkgid_by(dep.name, &dep.version),
-                        "dep_kinds": [
-                            {
-                                "kind": null,
+                "nodes": self.packages.iter().map(|package| {
+                    let mut all_deps = BTreeMap::<(&str, &Version), Vec<Option<&str>>>::new();
+                    for dep in &package.deps {
+                        all_deps.entry((dep.name, &dep.version)).or_default().push(None);
+                    }
+                    for dep in &package.build_deps {
+                        all_deps.entry((dep.name, &dep.version)).or_default().push(Some("build"));
+                    }
+                    for dep in &package.dev_deps {
+                        all_deps.entry((dep.name, &dep.version)).or_default().push(Some("dev"));
+                    }
+                    json!({
+                        "id": self.pkgid(package),
+                        "dependencies": all_deps.keys().map(|(name, version)| self.pkgid_by(name, version)).collect::<Vec<_>>(),
+                        "deps": all_deps.iter().map(|((name, version), kinds)| json!({
+                            "name": name,
+                            "pkg": self.pkgid_by(name, version),
+                            "dep_kinds": kinds.iter().map(|kind| json!({
+                                "kind": kind,
                                 "target": null,
-                            }
-                        ],
-                    })).collect::<Vec<_>>(),
-                })).collect::<Vec<_>>(),
+                            })).collect::<Vec<_>>(),
+                        })).collect::<Vec<_>>(),
+                    })
+                }).collect::<Vec<_>>(),
                 "root": null,
             },
             "target_directory": "C:\\FAKE\\target",
@@ -614,6 +648,35 @@ fn files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFi
     (config, audits, imports)
 }
 
+fn builtin_files_inited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFile) {
+    init_files(metadata).unwrap()
+}
+
+fn builtin_files_no_unaudited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFile) {
+    let (mut config, audits, imports) = builtin_files_inited(metadata);
+
+    // Just clear all the unaudited entries out
+    config.unaudited.clear();
+
+    (config, audits, imports)
+}
+fn builtin_files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFile) {
+    let (config, mut audits, imports) = builtin_files_no_unaudited(metadata);
+
+    let mut audited = StableMap::<String, Vec<AuditEntry>>::new();
+    for package in &metadata.packages {
+        if package.is_third_party() {
+            audited
+                .entry(package.name.clone())
+                .or_insert(vec![])
+                .push(full_audit(package.version.clone(), SAFE_TO_DEPLOY));
+        }
+    }
+    audits.audits = audited;
+
+    (config, audits, imports)
+}
+
 fn get_report(metadata: &Metadata, report: Report) -> String {
     let cfg = Config {
         metacfg: MetaConfig(vec![]),
@@ -672,6 +735,50 @@ fn mock_simple_full_audited() {
 
     let stdout = get_report(&metadata, report);
     insta::assert_snapshot!("mock-simple-full-audited", stdout);
+}
+
+#[test]
+fn mock_builtin_simple_init() {
+    // (Pass) Should look the same as a fresh 'vet init'.
+
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_inited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-simple-init", stdout);
+}
+
+#[test]
+fn mock_builtin_simple_no_unaudited() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-simple-no-unaudited", stdout);
+}
+
+#[test]
+fn mock_builtin_simple_full_audited() {
+    // (Pass) All entries have direct full audits.
+
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_full_audited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-simple-full-audited", stdout);
 }
 
 #[test]
@@ -1271,6 +1378,19 @@ fn mock_simple_delta_to_too_weak_full_audit() {
 }
 
 #[test]
+fn mock_complex_inited() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+
+    let mock = MockMetadata::complex();
+    let metadata = mock.metadata();
+    let (config, audits, imports) = files_inited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-complex-inited", stdout);
+}
+
+#[test]
 fn mock_complex_no_unaudited() {
     // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
 
@@ -1294,6 +1414,45 @@ fn mock_complex_full_audited() {
     let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
     let stdout = get_report(&metadata, report);
     insta::assert_snapshot!("mock-complex-full-audited", stdout);
+}
+
+#[test]
+fn mock_builtin_complex_inited() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+
+    let mock = MockMetadata::complex();
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_inited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-complex-inited", stdout);
+}
+
+#[test]
+fn mock_builtin_complex_no_unaudited() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+
+    let mock = MockMetadata::complex();
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-complex-no-unaudited", stdout);
+}
+
+#[test]
+fn mock_builtin_complex_full_audited() {
+    // (Pass) All entries have direct full audits.
+
+    let mock = MockMetadata::complex();
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_full_audited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("mock-builtin-complex-full-audited", stdout);
 }
 
 #[test]
@@ -1696,6 +1855,49 @@ fn mock_simple_first_policy_redundant() {
     let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
     let stdout = get_report(&metadata, report);
     insta::assert_snapshot!("simple-policy-first-policy-redundant", stdout);
+}
+
+#[test]
+fn builtin_simple_deps_inited() {
+    // (Pass) Should look the same as a fresh 'vet init'.
+    let mock = MockMetadata::simple_deps();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_inited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("builtin-simple-deps-init", stdout);
+}
+
+#[test]
+fn builtin_simple_deps_no_unaudited() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+
+    let mock = MockMetadata::simple_deps();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("builtin-simple-deps-no-unaudited", stdout);
+}
+
+#[test]
+fn builtin_simple_deps_full_audited() {
+    // (Pass) All entries have direct full audits.
+
+    let mock = MockMetadata::simple_deps();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_full_audited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("builtin-simple-deps-full-audited", stdout);
 }
 
 // TESTING BACKLOG:

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1910,6 +1910,54 @@ fn builtin_simple_deps_full_audited() {
     insta::assert_snapshot!("builtin-simple-deps-full-audited", stdout);
 }
 
+#[test]
+fn builtin_no_deps() {
+    // (Pass) No actual deps
+    let mock = MockMetadata::new(vec![MockPackage {
+        name: "root-package",
+        is_root: true,
+        is_first_party: true,
+        deps: vec![],
+        ..Default::default()
+    }]);
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_full_audited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("builtin-no-deps", stdout);
+}
+
+#[test]
+fn builtin_only_first_deps() {
+    // (Pass) No actual deps
+    let mock = MockMetadata::new(vec![
+        MockPackage {
+            name: "root-package",
+            is_root: true,
+            is_first_party: true,
+            deps: vec![dep("first-party")],
+            ..Default::default()
+        },
+        MockPackage {
+            name: "first-party",
+            is_first_party: true,
+            deps: vec![],
+            ..Default::default()
+        },
+    ]);
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_full_audited(&metadata);
+
+    let report = crate::resolver::resolve(&metadata, &config, &audits, &imports, false);
+
+    let stdout = get_report(&metadata, report);
+    insta::assert_snapshot!("builtin-only-first-deps", stdout);
+}
+
 // TESTING BACKLOG:
 //
 // * custom policies

--- a/tests/snapshots/test_cli__test-project.snap
+++ b/tests/snapshots/test_cli__test-project.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 129
+assertion_line: 131
 expression: stdout
 ---
-Vetting Succeeded (6 fully audited, 1 partially audited, 98 unaudited)
+Vetting Succeeded (5 fully audited, 1 partially audited, 98 unaudited)
 


### PR DESCRIPTION
This reworks the resolver in two major ways:

* We use the cargo-metadata structures to compute our own structures and then stop looking at them, preferring interned package ids over raw strings
* We attempt to more correctly handle the build-and-dev distinctions by doing two-phase analysis in several places
  * When computing our topological sort, we first ignore dev-deps to get the "normal" build graph and compute roots, then we augment the graph by visiting dev-deps
  * When resolving we now have a second pass `resolve_dev` step that is essentially the same as `resolve_first_party` but which only looks at dev-deps and does not record any successes. This essentially emulates a virtual root "dev" node on top of the real node.

(I also did some drive-by requested output cleanups and had to insert some more manual sorting that was only incidentally happening because packageids are already name+version.)

Current quirks that fall out of this implementation:

* At no point do we ever distinguish build-deps from normal-deps. In implementation I realized the semantics of build-policies are weird to try to implement via "bubble ups". Also I have potentially convinced myself that we might be able to get away with eliminating the normal-build distinction by claiming the following adjustment to safe-to-deploy: for crates which exist to generate code like proc-macros and cc, "safe-to-deploy" refers to the *generated* code, and not the implementation itself. This is usually pretty clear because there aren't many crates that are incidentally used for builds that aren't *explicitly* for that purpose! This is certainly true for all proc-macros!

* dev-deps are only every analyzed in the context of a virtual root node. As such, it is "impossible" to inherit policies from a parent and so we only ever use a build-and-dev policy directly on the node or the default root build-and-dev policy. I think this actually makes sense: **the quality of a particular package's tests has literally no impact on its parents**, and I don't really see a reason why the tests for a particular subtree would have higher or lower standards? They're just tests!