### PR TITLE
Add locks and proper file management facades

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -112,10 +112,10 @@ pub struct CriteriaEntry {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct AuditEntry {
     pub who: Option<String>,
+    pub notes: Option<String>,
     pub criteria: String,
     #[serde(flatten)]
     pub kind: AuditKind,
-    pub notes: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,8 +9,6 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::VetError;
-
 pub type StableMap<K, V> = linked_hash_map::LinkedHashMap<K, V>;
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -30,10 +28,10 @@ pub struct MetaConfigInstance {
     // (not sure whether this versions the format, or semantics, or...
     // for now assuming this species global semantics of some kind.
     pub version: Option<u64>,
-    pub store: Option<Store>,
+    pub store: Option<StoreInfo>,
 }
 #[derive(serde::Deserialize)]
-pub struct Store {
+pub struct StoreInfo {
     pub path: Option<PathBuf>,
 }
 
@@ -91,22 +89,6 @@ pub struct AuditsFile {
     pub criteria: StableMap<String, CriteriaEntry>,
     /// Actual audits.
     pub audits: AuditedDependencies,
-}
-
-impl AuditsFile {
-    pub fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        // * check that each CriteriaEntry has 'description' or 'description_url'
-        // * check that all criteria are valid in:
-        //   * CriteriaEntry::implies
-        //   * AuditEntry::criteria
-        //   * DependencyCriteria
-        // * check that all 'audits' entries are well-formed
-        // * check that all package names are valid (with crates.io...?)
-        // * check that all reviews have a 'who' (currently an Option to stub it out)
-        // * catch no-op deltas?
-        Ok(())
-    }
 }
 
 /// Information on a Criteria
@@ -251,17 +233,6 @@ pub struct ConfigFile {
     #[serde(skip_serializing_if = "StableMap::is_empty")]
     #[serde(default)]
     pub unaudited: StableMap<String, Vec<UnauditedDependency>>,
-}
-
-impl ConfigFile {
-    pub fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        //
-        // * check that policy entries are only first-party
-        // * check that unaudited entries are for things that exist?
-        // * check that lockfile and imports aren't desync'd (catch new/removed import urls)
-        Ok(())
-    }
 }
 
 pub static SAFE_TO_DEPLOY: &str = "safe-to-deploy";
@@ -461,13 +432,6 @@ fn is_default_unaudited_suggest(val: &bool) -> bool {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ImportsFile {
     pub audits: StableMap<String, AuditsFile>,
-}
-
-impl ImportsFile {
-    pub fn validate(&self) -> Result<(), VetError> {
-        // TODO
-        Ok(())
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -99,6 +99,11 @@ OPTIONS:
     -p, --package <SPEC>
             Package to process (see `cargo help pkgid`)
 
+        --readonly-lockless
+            Do not modify or lock the store (supply-chain) directory
+            
+            This is primarily intended for testing and should not be used without good reason.
+
     -V, --version
             Print version information
 

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -106,6 +106,11 @@ The format of the output
 #### `-p, --package <SPEC>`
 Package to process (see `cargo help pkgid`)
 
+#### `--readonly-lockless`
+Do not modify or lock the store (supply-chain) directory
+
+This is primarily intended for testing and should not be used without good reason.
+
 #### `-V, --version`
 Print version information
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -48,6 +48,9 @@ OPTIONS:
     -p, --package <SPEC>
             Package to process (see `cargo help pkgid`)
 
+        --readonly-lockless
+            Do not modify or lock the store (supply-chain) directory
+
     -V, --version
             Print version information
 

--- a/tests/test-cli.rs
+++ b/tests/test-cli.rs
@@ -65,8 +65,8 @@ fn test_long_help() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     assert!(output.status.success(), "{}", stderr);
-    insta::assert_snapshot!("long-help", stdout);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("long-help", stdout);
 }
 
 #[test]
@@ -84,8 +84,8 @@ fn test_short_help() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     assert!(output.status.success(), "{}", stderr);
-    insta::assert_snapshot!("short-help", stdout);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("short-help", stdout);
 }
 
 #[test]
@@ -103,8 +103,8 @@ fn test_markdown_help() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     assert!(output.status.success(), "{}", stderr);
-    insta::assert_snapshot!("markdown-help", stdout);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("markdown-help", stdout);
 }
 
 #[test]
@@ -116,6 +116,7 @@ fn test_project() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--manifest-path")
         .arg("Cargo.toml")
         .arg("--diff-cache")
@@ -128,9 +129,9 @@ fn test_project() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project", stdout);
 }
 
 #[test]
@@ -142,6 +143,7 @@ fn test_project_json() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--manifest-path")
         .arg("Cargo.toml")
         .arg("--diff-cache")
@@ -155,9 +157,9 @@ fn test_project_json() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-json", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-json", stdout);
 }
 
 #[test]
@@ -169,6 +171,7 @@ fn test_project_suggest() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -182,9 +185,9 @@ fn test_project_suggest() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-suggest", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-suggest", stdout);
 }
 
 #[test]
@@ -196,6 +199,7 @@ fn test_project_suggest_json() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -210,9 +214,9 @@ fn test_project_suggest_json() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-suggest-json", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-suggest-json", stdout);
 }
 
 #[test]
@@ -224,6 +228,7 @@ fn test_project_suggest_deeper() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -238,9 +243,9 @@ fn test_project_suggest_deeper() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-suggest-deeper", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-suggest-deeper", stdout);
 }
 
 #[test]
@@ -252,6 +257,7 @@ fn test_project_suggest_deeper_json() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -267,9 +273,9 @@ fn test_project_suggest_deeper_json() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-suggest-deeper-json", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-suggest-deeper-json", stdout);
 }
 
 #[test]
@@ -281,6 +287,7 @@ fn test_project_dump_graph_full_json() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -296,9 +303,9 @@ fn test_project_dump_graph_full_json() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-dump-graph-full-json", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-dump-graph-full-json", stdout);
 }
 
 #[test]
@@ -310,6 +317,7 @@ fn test_project_dump_graph_full() {
     let output = Command::new(bin)
         .current_dir(&project)
         .arg("vet")
+        .arg("--readonly-lockless")
         .arg("--diff-cache")
         .arg("../diff-cache.toml")
         .arg("--manifest-path")
@@ -324,7 +332,7 @@ fn test_project_dump_graph_full() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    insta::assert_snapshot!("test-project-dump-graph-full", stdout);
     assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
+    insta::assert_snapshot!("test-project-dump-graph-full", stdout);
 }

--- a/tests/test-cli.rs
+++ b/tests/test-cli.rs
@@ -38,7 +38,7 @@ fn test_version() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 
     let (name, ver) = stdout.split_once(' ').unwrap();
@@ -64,7 +64,7 @@ fn test_long_help() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     insta::assert_snapshot!("long-help", stdout);
     assert_eq!(stderr, "");
 }
@@ -83,7 +83,7 @@ fn test_short_help() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     insta::assert_snapshot!("short-help", stdout);
     assert_eq!(stderr, "");
 }
@@ -102,7 +102,7 @@ fn test_markdown_help() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     insta::assert_snapshot!("markdown-help", stdout);
     assert_eq!(stderr, "");
 }
@@ -129,7 +129,7 @@ fn test_project() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -156,7 +156,7 @@ fn test_project_json() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-json", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -183,7 +183,7 @@ fn test_project_suggest() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-suggest", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -211,7 +211,7 @@ fn test_project_suggest_json() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-suggest-json", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -239,7 +239,7 @@ fn test_project_suggest_deeper() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-suggest-deeper", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -268,7 +268,7 @@ fn test_project_suggest_deeper_json() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-suggest-deeper-json", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -297,7 +297,7 @@ fn test_project_dump_graph_full_json() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-dump-graph-full-json", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }
 
@@ -325,6 +325,6 @@ fn test_project_dump_graph_full() {
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     insta::assert_snapshot!("test-project-dump-graph-full", stdout);
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     assert_eq!(stderr, "");
 }

--- a/tests/test-project/supply-chain/audits.toml
+++ b/tests/test-project/supply-chain/audits.toml
@@ -3,7 +3,7 @@
 
 [criteria.audited]
 description = "super audited"
-implies = ["safe-to-deploy"]
+implies = "safe-to-deploy"
 
 [criteria.fuzzed]
 description = "fuzzed"
@@ -46,7 +46,10 @@ version = "1.1.0"
 notes = "test for custom criteria (low-grade and high-grade)"
 criteria = "safe-to-deploy"
 version = "3.1.8"
-dependency-criteria = { atty = ["safe-to-run"], bitflags = ["audited", "fuzzed"] }
+
+[audits.clap.dependency-criteria]
+atty = ["safe-to-run"]
+bitflags = ["audited", "fuzzed"]
 
 [[audits.atty]]
 criteria = "safe-to-run"


### PR DESCRIPTION
Fixes #115 

* New FileLock type for managing a lockfile, used for both the cache and supply-chain (separate locks)
* New Store type that wraps config.toml/audits.toml/imports.lock
  * Manages acquiring the FileLock
  * Manages loading the files and validating their consistency (stubbed, not implemented)
  * Manages fetching imports and checking for criteria changes (checking is stubbed)
  * Manages storing the files back (only done when manually requested by a command to avoid changes on-error)
* All commands that touch supply-chain now unconditionally acquire it and commit it on success
  * This means every (non-freestanding, non-debug) command will try to validate+fetch-imports+fmt

Drive-by changes:

* `notes` on audits were moved back up due to [limitations in toml-rs around nested tables](https://github.com/alexcrichton/toml-rs/issues/142). More aggressively trying to fmt+commit exposed this issue
* --readonly-lockless was added as a hack to disable the supply-chain lock for concurrent tests
